### PR TITLE
added version number (0.4.44) to 'servo:servo-core' dependency and suppo...

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,13 +27,14 @@ subprojects {
 
 project(':evcache-client') {
     apply plugin: 'java'
+    apply plugin: 'maven'
     dependencies {
     	compile     'net.spy:spymemcached:2.9.1'
         compile     'com.netflix.governator:governator:1.0.4'
         compile     'com.netflix.eureka:eureka-client:1.1.73'
         compile     'com.netflix.eureka:eureka-core:1.1.73'
         compile     'com.netflix.archaius:archaius-core:0.5.4'
-        compile     'com.netflix.servo:servo-core:'
+        compile     'com.netflix.servo:servo-core:0.4.44'
         compile     'org.slf4j:slf4j-log4j12:1.7.0'
         compile     'junit:junit:4.10'
         compile     'log4j:log4j:1.2.17'


### PR DESCRIPTION
This commit enables gradle task "install", which installs the evcache jars in the local Maven repostory. 

Since the version number  for the "servo:servo-core" dependency was not specified, this was preventing the resulting jar to be successfully installed in the local maven repository (since it's a mandatory POM parameter).
