### PR TITLE
Enable Eclipse and Maven plugins on gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ subprojects {
 project(':evcache-client') {
     apply plugin: 'java'
     apply plugin: 'maven'
+    apply plugin: 'eclipse'
     dependencies {
     	compile     'net.spy:spymemcached:2.9.1'
         compile     'com.netflix.governator:governator:1.0.4'


### PR DESCRIPTION
This pull request enables gradle tasks _install_ (maven) and _eclipse_. The _install_ task installs the evcache jars in the local Maven repository. The _eclipse_ task creates a java eclipse project within "evcache-client" directory, allowing the project to be imported from eclipse.

In order to enable the maven _install_ task, the version of the "servo:servo-core" dependency was specified as 0.4.44, otherwise the POM is not correctly generated.
