### PR TITLE
Interface additions for increased testability and semi-compatibility with spymemcached client.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ subprojects {
 project(':evcache-client') {
     apply plugin: 'java'
     apply plugin: 'maven'
+    apply plugin: 'eclipse'
     dependencies {
     	compile     'net.spy:spymemcached:2.9.1'
         compile     'com.netflix.governator:governator:1.0.4'

--- a/evcache-client/src/main/java/com/netflix/evcache/EVCache.java
+++ b/evcache-client/src/main/java/com/netflix/evcache/EVCache.java
@@ -16,6 +16,7 @@
 
 package com.netflix.evcache;
 
+import java.net.SocketAddress;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.Future;
@@ -359,4 +360,65 @@ public interface EVCache {
             return cache;
         }
     }
+
+    /**
+     * Flush all caches from all servers from all zones immediately.
+     *
+     * @return whether or not the operation was performed
+     * @throws EVCacheException if no client is found or in the
+     * rare circumstance where queue is too full to accept any more requests
+     */
+    Future<Boolean>[] flushAll() throws EVCacheException;
+
+    /**
+     * Shuts down this EVCache instance by shutting down all clients from all zones.
+     *
+     * @return whether or not the operation was performed
+     */
+    void shutdown();
+
+    /**
+     * Get the default transcoder that's in use.
+     *
+     * @return this instance's Transcoder
+     */
+    EVCacheTranscoder<?> getTranscoder();
+
+    /**
+     * Get the addresses of available servers in the local zone (or the global zone, if it is not zone-based).
+     *
+     * <p>
+     * This is based on a snapshot in time so shouldn't be considered completely
+     * accurate, but is a useful for getting a feel for what's working and what's
+     * not working.
+     * </p>
+     *
+     * @return point-in-time view of currently available servers in the local zone
+     * @throws EVCacheException if there are no available local clients or
+     *          in the rare circumstance where queue is too full to accept any more requests
+     */
+    Collection<SocketAddress> getLocalAvailableServers() throws EVCacheException;
+
+    /**
+     * Get the addresses of unavailable servers in the local zone (or the global zone, if it is not zone-based).
+     *
+     * <p>
+     * This is based on a snapshot in time so shouldn't be considered completely
+     * accurate, but is a useful for getting a feel for what's working and what's
+     * not working.
+     * </p>
+     *
+     * @return point-in-time view of currently unavailable servers in the local zone
+     * @throws EVCacheException if there are no available local clients or
+     *          in the rare circumstance where queue is too full to accept any more requests
+     */
+    Collection<SocketAddress> getLocalUnavailableServers()  throws EVCacheException;
+
+    /**
+     * Get all of the stats from all of the connections in the local zone.
+     * @return a Map of a Map of stats replies by SocketAddress of the local zone
+     * @throws EVCacheException if there are no available local clients or
+     *          in the rare circumstance where queue is too full to accept any more requests
+     */
+    public Map<SocketAddress, Map<String, String>> getLocalStats()  throws EVCacheException;
 }

--- a/evcache-client/src/main/java/com/netflix/evcache/EVCacheException.java
+++ b/evcache-client/src/main/java/com/netflix/evcache/EVCacheException.java
@@ -21,7 +21,7 @@ package com.netflix.evcache;
  * Base exception class for any error conditions that occur while using an EVCache client
  * to make service calls to EVCache Server.
  */
-public class EVCacheException extends Exception {
+public class EVCacheException extends RuntimeException {
 
     private static final long serialVersionUID = -3885811159646046383L;
 

--- a/evcache-client/src/main/java/com/netflix/evcache/pool/AbstractEVCacheClientImpl.java
+++ b/evcache-client/src/main/java/com/netflix/evcache/pool/AbstractEVCacheClientImpl.java
@@ -27,7 +27,6 @@ import net.spy.memcached.CASValue;
 import net.spy.memcached.ConnectionFactory;
 import net.spy.memcached.DefaultConnectionFactory;
 import net.spy.memcached.DefaultHashAlgorithm;
-import net.spy.memcached.HashAlgorithm;
 import net.spy.memcached.MemcachedClient;
 import net.spy.memcached.transcoders.Transcoder;
 
@@ -119,6 +118,13 @@ public abstract class AbstractEVCacheClientImpl implements EVCacheClient {
         return client.shutdown(timeout, unit);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    public void shutdown() {
+        shutdown = true;
+        client.shutdown();
+    }
 
     /**
      * {@inheritDoc}
@@ -247,6 +253,12 @@ public abstract class AbstractEVCacheClientImpl implements EVCacheClient {
         return client.getStats(cmd);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    public Map<SocketAddress, Map<String, String>> getStats() {
+        return client.getStats();
+    }
 
     /**
      * {@inheritDoc}
@@ -275,6 +287,26 @@ public abstract class AbstractEVCacheClientImpl implements EVCacheClient {
         return readTimeout.get();
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    public Future<Boolean> flush() {
+        return client.flush();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Collection<SocketAddress> getAvailableServers() {
+        return client.getAvailableServers();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Collection<SocketAddress> getUnavailableServers() {
+        return client.getUnavailableServers();
+    }
 
     /**
      * The String representation of this instance.

--- a/evcache-client/src/main/java/com/netflix/evcache/pool/EVCacheClient.java
+++ b/evcache-client/src/main/java/com/netflix/evcache/pool/EVCacheClient.java
@@ -147,6 +147,10 @@ public interface EVCacheClient {
      */
     boolean shutdown(long timeout, TimeUnit unit);
 
+    /**
+     * Shut down immediately.
+     */
+    public void shutdown();
 
     /**
      * returns true if the Client has been shut down else false.
@@ -161,6 +165,14 @@ public interface EVCacheClient {
      * @return A Map of EVCache server SocketAddress to the stats command output. The value is a Map of key value pairs
      */
     Map<SocketAddress, Map<String, String>> getStats(String cmd);
+
+    /**
+     * Retrieves all stats across all the EVCache servers in the cluster and returns its value.
+     * This is mainly used for admin purpose
+     *
+     * @return A Map of EVCache server SocketAddress to the stats command output. The value is a Map of key value pairs
+     */
+    Map<SocketAddress, Map<String, String>> getStats();
 
     /**
      * Returns the Memcachec version running on the EVCache Server.
@@ -194,4 +206,41 @@ public interface EVCacheClient {
      * @return the timeout in milliseconds
      */
     int getReadTimeout();
+
+    /**
+     * Flush all caches from all servers immediately.
+     *
+     * @return whether or not the operation was performed
+     * @throws IllegalStateException in the rare circumstance where queue is too
+     *           full to accept any more requests
+     */
+    Future<Boolean> flush();
+
+    /**
+     * Get the addresses of available servers.
+     * This is mainly used for admin purposes.
+     *
+     * <p>
+     * This is based on a snapshot in time so shouldn't be considered completely
+     * accurate, but is a useful for getting a feel for what's working and what's
+     * not working.
+     * </p>
+     *
+     * @return point-in-time view of currently available servers for this client
+     */
+    Collection<SocketAddress> getAvailableServers();
+
+    /**
+     * Get the addresses of unavailable servers.
+     * This is mainly used for admin purposes.
+     *
+     * <p>
+     * This is based on a snapshot in time so shouldn't be considered completely
+     * accurate, but is a useful for getting a feel for what's working and what's
+     * not working.
+     * </p>
+     *
+     * @return point-in-time view of currently available servers for this client
+     */
+    Collection<SocketAddress> getUnavailableServers();
 }

--- a/evcache-client/src/main/java/com/netflix/evcache/pool/EVCacheClientPool.java
+++ b/evcache-client/src/main/java/com/netflix/evcache/pool/EVCacheClientPool.java
@@ -91,4 +91,13 @@ public interface EVCacheClientPool {
      * @return true if the pool supports request fallback else false.
      */
     boolean supportsFallback();
+
+    /**
+     * Retrieves the local zone where this instance is located.
+     * If this instance is deployed on EC2, it will return the EC2 availabilty zone string
+     * for the local zone. Otherwise, it will return "GLOBAL".
+     *
+     * @return The local zone identifier.
+     */
+    String getLocalZone();
 }

--- a/evcache-client/src/main/java/com/netflix/evcache/pool/EVCacheClientPoolManager.java
+++ b/evcache-client/src/main/java/com/netflix/evcache/pool/EVCacheClientPoolManager.java
@@ -125,4 +125,25 @@ public final class EVCacheClientPoolManager {
             pool.shutdown();
         }
     }
+
+    /**
+     * Will shutdown the given EVCache app pool and remove
+     * it from the list of pools of this manager.
+     *
+     * @param appName - name of the evcache app
+     */
+    public void destroy(String _appName) {
+        final String appName = _appName.toUpperCase();
+        if (!poolMap.containsKey(appName)) return;
+        lock.lock();
+        try {
+            if (!poolMap.containsKey(appName)) return;
+            final EVCacheClientPool pool = poolMap.remove(appName);
+            pool.shutdown();
+        } catch (Exception ex) {
+            log.error("Exception initialzing " + evcachePoolProvider + " for app " + appName, ex);
+        } finally {
+            lock.unlock();
+        }
+    }
 }

--- a/evcache-client/src/main/java/com/netflix/evcache/pool/eureka/EVCacheClientPoolImpl.java
+++ b/evcache-client/src/main/java/com/netflix/evcache/pool/eureka/EVCacheClientPoolImpl.java
@@ -683,4 +683,11 @@ public class EVCacheClientPoolImpl implements Runnable, EVCacheClientPoolImplMBe
     public int getClusterSize() {
         return memcachedInstancesByZone.size();
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public String getLocalZone() {
+        return _zone;
+    }
 }

--- a/evcache-client/src/main/java/com/netflix/evcache/pool/standalone/SimpleEVCacheClientPoolImpl.java
+++ b/evcache-client/src/main/java/com/netflix/evcache/pool/standalone/SimpleEVCacheClientPoolImpl.java
@@ -41,6 +41,8 @@ import com.netflix.servo.annotations.Monitor;
  *
  */
 public class SimpleEVCacheClientPoolImpl extends AbstractEVCacheClientPoolImpl implements SimpleEVCacheClientPoolImplMBean {
+    private static final String GLOBAL = "GLOBAL";
+
     private static Logger log = LoggerFactory.getLogger(SimpleEVCacheClientPoolImpl.class);
 
     private DynamicStringProperty _serverList; //List of servers
@@ -254,6 +256,13 @@ public class SimpleEVCacheClientPoolImpl extends AbstractEVCacheClientPoolImpl i
      */
     public int getClusterSize() {
         return 1;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public String getLocalZone() {
+        return GLOBAL;
     }
 
     /**

--- a/evcache-client/src/main/java/com/netflix/evcache/pool/standalone/ZoneClusteredEVCacheClientPoolImpl.java
+++ b/evcache-client/src/main/java/com/netflix/evcache/pool/standalone/ZoneClusteredEVCacheClientPoolImpl.java
@@ -537,6 +537,13 @@ public class ZoneClusteredEVCacheClientPoolImpl extends AbstractEVCacheClientPoo
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public String getLocalZone() {
+        return _zone;
+    }
+
+    /**
      * String representation of this instance.
      */
     public String toString() {


### PR DESCRIPTION
This PR adds some features to EVCache's interfaces, mostly to keep EVCache's interface semi-compatible with spymemcached, allowing users to make a smoother transition between spymemcached and evcache clients.

The additions on this PR include:
* *EVCacheException:* Turned into a RuntimeException.
 * *Reasoning*: Since EVCacheException is thrown by nearly all methods of *com.netflix.evcache.EVCache*, it forces clients to surround EVCache's method calls in a "try catch", even if the "throw.exception" property is set to false (fast failure mode).

* *EVCacheClientPool:* Added method getLocalZone().
 * *Reasoning*: Allows clients of Zone-based EVCacheClientPool to easily retrieve the local zone. 

* *EVCacheClientPoolManager:* Added destroy(appName) method.
 * *Reasoning*: the main reason for this change is to improve testability, since shutting down a pool managed by EVCacheClientPoolManager prevents a new EVCacheClientPool to be instantiated (in a subsequent test, for example). So, the destroy(appName) basically shutdowns an app's pool and remove it from the list of pools managed by the EVCacheClientPoolManager.

* *EVCacheClient:* Added proxy methods to support (spy)MemcachedClient methods: getUnavailableServers(), getAvailableServers(), flush(), getStats(), shutdown().
 * *Reasoning*: semi-compatibility between EVCacheClient and MemCachedClient.

* *EVCache:* added support to auxiliar methods that will aid in testing and administration (flushAll(), shutdown(), getTranscoder(), getLocalAvailableServers(), getLocalUnavailableServers(), getLocalStats())
 * *Reasoning*: testability and semi-compatibility between EVCache and MemCachedClient.