### PR TITLE
Load 'evcache' configuration in EVCacheClientPoolManager

### DIFF
--- a/evcache-client/src/main/java/com/netflix/evcache/EVCacheModule.java
+++ b/evcache-client/src/main/java/com/netflix/evcache/EVCacheModule.java
@@ -1,10 +1,7 @@
 package com.netflix.evcache;
 
-import java.io.IOException;
-
 import com.google.inject.AbstractModule;
 import com.google.inject.Singleton;
-import com.netflix.config.ConfigurationManager;
 import com.netflix.evcache.pool.EVCacheClientPoolManager;
 
 @Singleton
@@ -15,11 +12,6 @@ public class EVCacheModule extends AbstractModule {
 
     @Override
     protected void configure() {
-        try {
-            ConfigurationManager.loadAppOverrideProperties("evcache");
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
         bind(EVCacheClientPoolManager.class).asEagerSingleton();
 
         // Make sure connection factory provider Module is initialized in your Module when you init EVCacheModule 

--- a/evcache-client/src/main/java/com/netflix/evcache/pool/EVCacheClientPoolManager.java
+++ b/evcache-client/src/main/java/com/netflix/evcache/pool/EVCacheClientPoolManager.java
@@ -85,6 +85,13 @@ public class EVCacheClientPoolManager {
     public EVCacheClientPoolManager(ApplicationInfoManager applicationInfoManager, DiscoveryClient discoveryClient,
             Provider<IConnectionFactoryProvider> connectionFactoryprovider) {
         instance = this;
+        
+        try {
+            ConfigurationManager.loadPropertiesFromResources("evcache");
+        } catch (IOException e) {
+            log.info("Default evcache configuration not loaded", e);
+        }
+
         this.applicationInfoManager = applicationInfoManager;
         this.discoveryClient = discoveryClient;
         this.connectionFactoryprovider = connectionFactoryprovider;


### PR DESCRIPTION
Decouple configuration loading from Guice and make it part of EVCacheClientPoolManager.  When writing Guice modules it's best that configure() not have any side effects as that can result in an ordering dependency and break overrides. 

Also, make sure evcache configuration is loaded into the library layer of archaius and not the application override layer, which should be reserved for an applications only.