### PR TITLE
Remove installViaTravis.sh from install phase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 jdk:
 - oraclejdk8
 sudo: false
-install: ./installViaTravis.sh
+#install: ./installViaTravis.sh
 script: ./buildViaTravis.sh
 cache:
   directories:


### PR DESCRIPTION
It looks like gradle has become stricter in evaluating
`project.ext['release.stage']` and blows up when it can't infer the
release stage.

For the `assemble` task, there is no inferred stage.

This change will force all the work to in the next script, i.e.
`buildViaTravis.sh`.

@smadappa @rspieldenner @OdysseusLives 