### PR TITLE
Replace DiscoveryClient with EurekaClient

### DIFF
--- a/evcache-client/src/main/java/com/netflix/evcache/connection/DIConnectionFactory.java
+++ b/evcache-client/src/main/java/com/netflix/evcache/connection/DIConnectionFactory.java
@@ -1,29 +1,28 @@
 package com.netflix.evcache.connection;
 
-import java.util.List;
-
 import com.netflix.config.DynamicIntProperty;
-import com.netflix.discovery.DiscoveryClient;
+import com.netflix.discovery.EurekaClient;
 import com.netflix.evcache.pool.DIEVCacheKetamaNodeLocatorConfiguration;
 import com.netflix.evcache.pool.EVCacheClient;
 import com.netflix.evcache.pool.EVCacheNodeLocator;
-
 import net.spy.memcached.DefaultHashAlgorithm;
 import net.spy.memcached.MemcachedNode;
 import net.spy.memcached.NodeLocator;
 
+import java.util.List;
+
 public class DIConnectionFactory extends BaseConnectionFactory {
 
-    private final DiscoveryClient discoveryClient;
-    
-    DIConnectionFactory(EVCacheClient client, DiscoveryClient discoveryClient, int len, DynamicIntProperty operationTimeout, long opMaxBlockTime) {
+    private final EurekaClient eurekaClient;
+
+    DIConnectionFactory(EVCacheClient client, EurekaClient eurekaClient, int len, DynamicIntProperty operationTimeout, long opMaxBlockTime) {
         super(client, len, operationTimeout, opMaxBlockTime);
-        this.discoveryClient = discoveryClient;
+        this.eurekaClient = eurekaClient;
     }
 
     @Override
     public NodeLocator createLocator(List<MemcachedNode> list) {
-        this.locator = new EVCacheNodeLocator(client, list,  DefaultHashAlgorithm.KETAMA_HASH, new DIEVCacheKetamaNodeLocatorConfiguration(client, discoveryClient));
+        this.locator = new EVCacheNodeLocator(client, list,  DefaultHashAlgorithm.KETAMA_HASH, new DIEVCacheKetamaNodeLocatorConfiguration(client, eurekaClient));
         return locator;
     }
 

--- a/evcache-client/src/main/java/com/netflix/evcache/connection/DIConnectionFactoryBuilderProvider.java
+++ b/evcache-client/src/main/java/com/netflix/evcache/connection/DIConnectionFactoryBuilderProvider.java
@@ -4,6 +4,7 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.netflix.config.DynamicIntProperty;
 import com.netflix.discovery.DiscoveryClient;
+import com.netflix.discovery.EurekaClient;
 import com.netflix.evcache.pool.EVCacheClient;
 import com.netflix.evcache.util.EVCacheConfig;
 
@@ -11,11 +12,11 @@ import net.spy.memcached.ConnectionFactory;
 
 public class DIConnectionFactoryBuilderProvider extends ConnectionFactoryBuilder implements Provider<IConnectionBuilder> {
 
-    private final DiscoveryClient discoveryClient;
+    private final EurekaClient eurekaClient;
 
     @Inject
-    public DIConnectionFactoryBuilderProvider(DiscoveryClient discoveryClient) {
-        this.discoveryClient = discoveryClient;
+    public DIConnectionFactoryBuilderProvider(EurekaClient eurekaClient) {
+        this.eurekaClient = eurekaClient;
     }
     @Override
     public ConnectionFactoryBuilder get() {
@@ -29,7 +30,7 @@ public class DIConnectionFactoryBuilderProvider extends ConnectionFactoryBuilder
         final DynamicIntProperty operationTimeout = EVCacheConfig.getInstance().getDynamicIntProperty(appName + ".operation.timeout", 2500);
         final int opQueueMaxBlockTime = EVCacheConfig.getInstance().getDynamicIntProperty(appName + ".operation.QueueMaxBlockTime", 10).get();
 
-        return new DIConnectionFactory(client, discoveryClient, maxQueueSize, operationTimeout, opQueueMaxBlockTime);
+        return new DIConnectionFactory(client, eurekaClient, maxQueueSize, operationTimeout, opQueueMaxBlockTime);
     }
 
 }

--- a/evcache-client/src/main/java/com/netflix/evcache/pool/DIEVCacheKetamaNodeLocatorConfiguration.java
+++ b/evcache-client/src/main/java/com/netflix/evcache/pool/DIEVCacheKetamaNodeLocatorConfiguration.java
@@ -1,26 +1,24 @@
 package com.netflix.evcache.pool;
 
+import com.netflix.appinfo.InstanceInfo;
+import com.netflix.discovery.EurekaClient;
+import com.netflix.discovery.shared.Application;
+import net.spy.memcached.MemcachedNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.netflix.appinfo.InstanceInfo;
-import com.netflix.discovery.DiscoveryClient;
-import com.netflix.discovery.shared.Application;
-
-import net.spy.memcached.MemcachedNode;
-
 public class DIEVCacheKetamaNodeLocatorConfiguration extends EVCacheKetamaNodeLocatorConfiguration {
 
     private static Logger log = LoggerFactory.getLogger(DIEVCacheKetamaNodeLocatorConfiguration.class);
-    private final DiscoveryClient discoveryClient;
+    private final EurekaClient eurekaClient;
 
-    public DIEVCacheKetamaNodeLocatorConfiguration(EVCacheClient client, DiscoveryClient discoveryClient) {
+    public DIEVCacheKetamaNodeLocatorConfiguration(EVCacheClient client, EurekaClient eurekaClient) {
         super(client);
-        this.discoveryClient = discoveryClient;
+        this.eurekaClient = eurekaClient;
     }
 
     /**
@@ -38,8 +36,8 @@ public class DIEVCacheKetamaNodeLocatorConfiguration extends EVCacheKetamaNodeLo
             final SocketAddress socketAddress = node.getSocketAddress();
             if(socketAddress instanceof InetSocketAddress) {
                 final InetSocketAddress isa = (InetSocketAddress)socketAddress;
-                if(discoveryClient != null ) {
-                    final Application app = discoveryClient.getApplication(client.getAppName());
+                if(eurekaClient != null ) {
+                    final Application app = eurekaClient.getApplication(client.getAppName());
                     if(app != null) {
                         final List<InstanceInfo> instances = app.getInstances();
                         for(InstanceInfo info : instances) {
@@ -70,6 +68,6 @@ public class DIEVCacheKetamaNodeLocatorConfiguration extends EVCacheKetamaNodeLo
 
     @Override
     public String toString() {
-        return "DIEVCacheKetamaNodeLocatorConfiguration [" + super.toString() + ", DiscoveryClient=" + discoveryClient + "]";
+        return "DIEVCacheKetamaNodeLocatorConfiguration [" + super.toString() + ", EurekaClient=" + eurekaClient + "]";
     }
 }

--- a/evcache-client/src/main/java/com/netflix/evcache/pool/eureka/DIEVCacheNodeListProvider.java
+++ b/evcache-client/src/main/java/com/netflix/evcache/pool/eureka/DIEVCacheNodeListProvider.java
@@ -2,6 +2,7 @@ package com.netflix.evcache.pool.eureka;
 
 import javax.inject.Provider;
 
+import com.netflix.discovery.EurekaClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,22 +16,22 @@ import com.netflix.evcache.util.EVCacheConfig;
 public class DIEVCacheNodeListProvider implements Provider<EVCacheNodeList> {
 
     private static Logger log = LoggerFactory.getLogger(DIEVCacheNodeListProvider.class);
-    private final DiscoveryClient discoveryClient;
+    private final EurekaClient eurekaClient;
     private final ApplicationInfoManager applicationInfoManager;
 
     @Inject
-    public DIEVCacheNodeListProvider(ApplicationInfoManager applicationInfoManager, DiscoveryClient discoveryClient) {
+    public DIEVCacheNodeListProvider(ApplicationInfoManager applicationInfoManager, EurekaClient eurekaClient) {
         this.applicationInfoManager = applicationInfoManager;
-        this.discoveryClient = discoveryClient;
+        this.eurekaClient = eurekaClient;
     }
 
     @Override
     public EVCacheNodeList get() {
         final EVCacheNodeList provider;
-        if (EVCacheConfig.getInstance().getDynamicBooleanProperty("evcache.use.simple.node.list.provider", false).get()) { 
+        if (EVCacheConfig.getInstance().getDynamicBooleanProperty("evcache.use.simple.node.list.provider", false).get()) {
             provider = new SimpleNodeListProvider();
         } else {
-            provider = new EurekaNodeListProvider(applicationInfoManager, discoveryClient);
+            provider = new EurekaNodeListProvider(applicationInfoManager, eurekaClient);
         }
         if(log.isDebugEnabled()) log.debug("EVCache Node List Provider : " + provider);
         return provider;


### PR DESCRIPTION
Replace some APIs that are used in Spring Boot to accept EurekaClient interface instead of the DiscoveryClient implementation.
This change should be backward compatible.