### PR TITLE
Add id tag to ipc metrics

### DIFF
--- a/evcache-client/src/main/java/com/netflix/evcache/pool/eureka/EurekaNodeListProvider.java
+++ b/evcache-client/src/main/java/com/netflix/evcache/pool/eureka/EurekaNodeListProvider.java
@@ -87,16 +87,16 @@ public class EurekaNodeListProvider implements EVCacheNodeList {
             // We checked above if this instance is Amazon so no need to do a instanceof check
             final String zone = amznInfo.get(AmazonInfo.MetaDataKey.availabilityZone);
             if(zone == null) {
-                final List<Tag> tagList = new ArrayList<Tag>(2);
-                tagList.add(new BasicTag(EVCacheMetricsFactory.CACHE, _appName));
+                final List<Tag> tagList = new ArrayList<Tag>(3);
+                EVCacheMetricsFactory.getInstance().addAppNameTags(tagList, _appName);
                 tagList.add(new BasicTag(EVCacheMetricsFactory.CONFIG_NAME, EVCacheMetricsFactory.NULL_ZONE));
                 EVCacheMetricsFactory.getInstance().increment(EVCacheMetricsFactory.CONFIG, tagList);
                 continue;
             }
             final String asgName = iInfo.getASGName();
             if(asgName == null) {
-                final List<Tag> tagList = new ArrayList<Tag>(2);
-                tagList.add(new BasicTag(EVCacheMetricsFactory.CACHE, _appName));
+                final List<Tag> tagList = new ArrayList<Tag>(3);
+                EVCacheMetricsFactory.getInstance().addAppNameTags(tagList, _appName);
                 tagList.add(new BasicTag(EVCacheMetricsFactory.CONFIG_NAME, EVCacheMetricsFactory.NULL_SERVERGROUP));
                 EVCacheMetricsFactory.getInstance().increment(EVCacheMetricsFactory.CONFIG, tagList);
                 continue;

--- a/evcache-core/src/main/java/com/netflix/evcache/EVCacheImpl.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/EVCacheImpl.java
@@ -111,8 +111,8 @@ final public class EVCacheImpl implements EVCache {
         this._zoneFallback = enableZoneFallback;
         this._throwException = throwException;
 
-        tags = new ArrayList<Tag>(2);
-        tags.add(new BasicTag(EVCacheMetricsFactory.CACHE, _appName));
+        tags = new ArrayList<Tag>(3);
+        EVCacheMetricsFactory.getInstance().addAppNameTags(tags, _appName);
         if(_cacheName != null && _cacheName.length() > 0) tags.add(new BasicTag(EVCacheMetricsFactory.PREFIX, _cacheName));
 
         final String _metricName = (_cacheName == null) ? _appName : _appName + "." + _cacheName;

--- a/evcache-core/src/main/java/com/netflix/evcache/metrics/EVCacheMetricsFactory.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/metrics/EVCacheMetricsFactory.java
@@ -94,7 +94,7 @@ public final class EVCacheMetricsFactory {
     }
     
     private void addCommonTags(List<Tag> tagList) {
-        tagList.add(new BasicTag("owner", "evcache"));
+        tagList.add(new BasicTag(OWNER, "evcache"));
         final String additionalTags = EVCacheConfig.getInstance().getPropertyRepository().get("evcache.additional.tags", String.class).orElse(null).get();
         if(additionalTags != null && additionalTags.length() > 0) {
             final StringTokenizer st = new StringTokenizer(additionalTags, ","); 
@@ -105,6 +105,11 @@ public final class EVCacheMetricsFactory {
                 if(val != null) tagList.add(new BasicTag(token, val));
             }
         }        
+    }
+
+    public void addAppNameTags(List<Tag> tagList, String appName) {
+        tagList.add(new BasicTag(EVCacheMetricsFactory.CACHE, appName));
+        tagList.add(new BasicTag(EVCacheMetricsFactory.ID, appName));
     }
 
     public Id getId(String name, Collection<Tag> tags) {
@@ -204,6 +209,7 @@ public final class EVCacheMetricsFactory {
     public static final String IPC_SIZE_OUTBOUND                    = "ipc.client.call.size.outbound";
 
     public static final String OWNER                                = "owner";
+    public static final String ID                                   = "id";
 
     /**
      * Internal Metric Names

--- a/evcache-core/src/main/java/com/netflix/evcache/operation/EVCacheLatchImpl.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/operation/EVCacheLatchImpl.java
@@ -245,8 +245,8 @@ public class EVCacheLatchImpl implements EVCacheLatch, Runnable {
             if (log.isDebugEnabled()) log.debug("App : " + evcacheEvent.getAppName() + "; Call : " + evcacheEvent.getCall() + "; Keys : " + evcacheEvent.getEVCacheKeys() + "; completeCount : " + completeCount + "; totalFutureCount : " + totalFutureCount +"; failureCount : " + failureCount);
         }
         if(totalFutureCount == completeCount) {
-            final List<Tag> tags = new ArrayList<Tag>(4);
-            tags.add(new BasicTag(EVCacheMetricsFactory.CACHE, appName));
+            final List<Tag> tags = new ArrayList<Tag>(5);
+            EVCacheMetricsFactory.getInstance().addAppNameTags(tags, appName);
             if(evcacheEvent != null) tags.add(new BasicTag(EVCacheMetricsFactory.CALL_TAG, evcacheEvent.getCall().name()));
             tags.add(new BasicTag(EVCacheMetricsFactory.FAIL_COUNT, String.valueOf(failureCount)));
             tags.add(new BasicTag(EVCacheMetricsFactory.COMPLETE_COUNT, String.valueOf(completeCount)));
@@ -438,8 +438,8 @@ public class EVCacheLatchImpl implements EVCacheLatch, Runnable {
                     }
                 }
             }
-            final List<Tag> tags = new ArrayList<Tag>(4);
-            tags.add(new BasicTag(EVCacheMetricsFactory.CACHE, appName));
+            final List<Tag> tags = new ArrayList<Tag>(5);
+            EVCacheMetricsFactory.getInstance().addAppNameTags(tags, appName);
             if(evcacheEvent != null) tags.add(new BasicTag(EVCacheMetricsFactory.CALL_TAG, evcacheEvent.getCall().name()));
             //tags.add(new BasicTag(EVCacheMetricsFactory.OPERATION, EVCacheMetricsFactory.VERIFY));
             tags.add(new BasicTag(EVCacheMetricsFactory.FAIL_COUNT, String.valueOf(failCount)));

--- a/evcache-core/src/main/java/com/netflix/evcache/pool/EVCacheClient.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/pool/EVCacheClient.java
@@ -117,8 +117,8 @@ public class EVCacheClient {
 //        this.operationTimeout = operationTimeout;
         this.pool = pool;
 
-        final List<Tag> tagList = new ArrayList<Tag>(3);
-        tagList.add(new BasicTag(EVCacheMetricsFactory.CACHE, appName));
+        final List<Tag> tagList = new ArrayList<Tag>(4);
+        EVCacheMetricsFactory.getInstance().addAppNameTags(tagList, appName);
         tagList.add(new BasicTag(EVCacheMetricsFactory.CONNECTION_ID, String.valueOf(id)));
         tagList.add(new BasicTag(EVCacheMetricsFactory.SERVERGROUP, serverGroup.getName()));
         this.tags = Collections.<Tag>unmodifiableList(new ArrayList(tagList));

--- a/evcache-core/src/main/java/com/netflix/evcache/pool/EVCacheClientPool.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/pool/EVCacheClientPool.java
@@ -146,8 +146,8 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
             setupClones();
         });
 
-        tagList = new ArrayList<Tag>(1);
-        tagList.add(new BasicTag(EVCacheMetricsFactory.CACHE, _appName));
+        tagList = new ArrayList<Tag>(2);
+        EVCacheMetricsFactory.getInstance().addAppNameTags(tagList, _appName);
 
         this._pingServers = config.getPropertyRepository().get(appName + ".ping.servers", Boolean.class).orElseGet("evcache.ping.servers").orElse(false);
         setupMonitoring();
@@ -987,8 +987,8 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
         Gauge gauge = gaugeMap.get(name );
         if(gauge != null) return gauge;
 
-        final List<Tag> tags = new ArrayList<Tag>(4);
-        tags.add(new BasicTag(EVCacheMetricsFactory.CACHE, _appName));
+        final List<Tag> tags = new ArrayList<Tag>(5);
+        EVCacheMetricsFactory.getInstance().addAppNameTags(tags, _appName);
         tags.add(new BasicTag(EVCacheMetricsFactory.CONFIG_NAME, metric));
         if(serverGroup != null) {
             tags.add(new BasicTag(EVCacheMetricsFactory.SERVERGROUP, serverGroup.getName()));
@@ -1005,8 +1005,8 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
         Gauge gauge = gaugeMap.get(name );
         if(gauge != null) return gauge;
 
-        final List<Tag> tags = new ArrayList<Tag>(3);
-        tags.add(new BasicTag(EVCacheMetricsFactory.CACHE, _appName));
+        final List<Tag> tags = new ArrayList<Tag>(4);
+        EVCacheMetricsFactory.getInstance().addAppNameTags(tags, _appName);
         tags.add(new BasicTag(EVCacheMetricsFactory.STAT_NAME, metric));
         tags.add(new BasicTag(EVCacheMetricsFactory.CONNECTION_ID, String.valueOf(client.getId())));
         tags.add(new BasicTag(EVCacheMetricsFactory.SERVERGROUP, client.getServerGroupName()));
@@ -1019,8 +1019,8 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
 
     private void incrementFailure(String metric, ServerGroup serverGroup) {
 
-        final List<Tag> tags = new ArrayList<Tag>(3);
-        tags.add(new BasicTag(EVCacheMetricsFactory.CACHE, _appName));
+        final List<Tag> tags = new ArrayList<Tag>(4);
+        EVCacheMetricsFactory.getInstance().addAppNameTags(tags, _appName);
         tags.add(new BasicTag(EVCacheMetricsFactory.CONFIG_NAME, metric));
         tags.add(new BasicTag(EVCacheMetricsFactory.SERVERGROUP, serverGroup.getName()));
 


### PR DESCRIPTION
Add an additional "id" tag to the metrics using whatever value has been chosen for "ipc.server.app"

This is to align with other implementations of the Common IPC Metrics where the ID tag should always be present.

@smadappa Let me know what you think about doing this, and/or if there's a better way to implement this that I can change to.