### PR TITLE
Fixing tag override problem for multiple cached keys.

### DIFF
--- a/evcache-zipkin-tracing/src/main/java/com/netflix/evcache/EVCacheTracingEventListener.java
+++ b/evcache-zipkin-tracing/src/main/java/com/netflix/evcache/EVCacheTracingEventListener.java
@@ -11,7 +11,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.StringJoiner;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /** Adds tracing tags for EvCache calls. */
 public class EVCacheTracingEventListener implements EVCacheEventListener {
@@ -35,6 +37,11 @@ public class EVCacheTracingEventListener implements EVCacheEventListener {
       Span clientSpan =
           this.tracer.nextSpan().kind(Span.Kind.CLIENT).name(EVCACHE_SPAN_NAME).start(e.getStartTime());
 
+      // Return if tracing has been disabled
+      if(clientSpan.isNoop()){
+        return;
+      }
+
       String appName = e.getAppName();
       this.safeTag(clientSpan, EVCacheTracingTags.APP_NAME, appName);
 
@@ -52,17 +59,17 @@ public class EVCacheTracingEventListener implements EVCacheEventListener {
        * attempt to write to its cache instance.
        */
       String serverGroup;
-      StringJoiner serverGroups = new StringJoiner(",", "[", "]");
+      List<String> serverGroups = new ArrayList<>();
       for (EVCacheClient client : e.getClients()) {
         serverGroup = client.getServerGroupName();
         if (StringUtils.isNotBlank(serverGroup)) {
           serverGroups.add("\"" + serverGroup + "\"");
         }
       }
-      clientSpan.tag(EVCacheTracingTags.SERVER_GROUPS, serverGroups.toString());
+      clientSpan.tag(EVCacheTracingTags.SERVER_GROUPS, serverGroups.stream().collect(Collectors.joining(",", "[", "]")));
 
       /**
-       * Note - EvCache client creates a hash key if the given canonical key size exceeds 255
+       * Note - EVCache client creates a hash key if the given canonical key size exceeds 255
        * characters.
        *
        * <p>There have been cases where canonical key size exceeded few megabytes. As caching client
@@ -70,13 +77,25 @@ public class EVCacheTracingEventListener implements EVCacheEventListener {
        * safe to annotate hash key instead of canonical key in such cases.
        */
       String hashKey;
+      List<String> hashKeys = new ArrayList<>();
+      List<String> canonicalKeys = new ArrayList<>();
       for (EVCacheKey keyObj : e.getEVCacheKeys()) {
         hashKey = keyObj.getHashKey();
         if (StringUtils.isNotBlank(hashKey)) {
-          clientSpan.tag(EVCacheTracingTags.HASH_KEY, hashKey);
+          hashKeys.add("\"" + hashKey + "\"");
         } else {
-          this.safeTag(clientSpan, EVCacheTracingTags.CANONICAL_KEY, keyObj.getCanonicalKey());
+          canonicalKeys.add("\"" + keyObj.getCanonicalKey() + "\"");
         }
+      }
+
+      if(hashKeys.size() > 0) {
+        this.safeTag(clientSpan, EVCacheTracingTags.HASH_KEYS,
+                hashKeys.stream().collect(Collectors.joining(",", "[", "]")));
+      }
+
+      if(canonicalKeys.size() > 0) {
+        this.safeTag(clientSpan, EVCacheTracingTags.CANONICAL_KEYS,
+                canonicalKeys.stream().collect(Collectors.joining(",", "[", "]")));
       }
 
       /**

--- a/evcache-zipkin-tracing/src/main/java/com/netflix/evcache/EVCacheTracingTags.java
+++ b/evcache-zipkin-tracing/src/main/java/com/netflix/evcache/EVCacheTracingTags.java
@@ -7,8 +7,8 @@ public class EVCacheTracingTags {
     public static String LATENCY = "evcache.latency";
     public static String CALL = "evcache.call";
     public static String SERVER_GROUPS = "evcache.server_groups";
-    public static String HASH_KEY = "evcache.hash_key";
-    public static String CANONICAL_KEY = "evcache.canonical_key";
+    public static String HASH_KEYS = "evcache.hash_keys";
+    public static String CANONICAL_KEYS = "evcache.canonical_keys";
     public static String DATA_TTL = "evcache.data_ttl";
     public static String DATA_SIZE = "evcache.data_size";
     public static String ERROR = "evcache.error";

--- a/evcache-zipkin-tracing/src/test/java/com/netflix/evcache/EVCacheTracingEventListenerUnitTests.java
+++ b/evcache-zipkin-tracing/src/test/java/com/netflix/evcache/EVCacheTracingEventListenerUnitTests.java
@@ -94,7 +94,7 @@ public class EVCacheTracingEventListenerUnitTests {
     Assert.assertTrue(tags.containsKey(EVCacheTracingTags.CACHE_NAME_PREFIX), "CACHE_NAME_PREFIX tag is missing");
     Assert.assertTrue(tags.containsKey(EVCacheTracingTags.CALL), "CALL tag is missing");
     Assert.assertTrue(tags.containsKey(EVCacheTracingTags.SERVER_GROUPS), "SERVER_GROUPS tag is missing");
-    Assert.assertTrue(tags.containsKey(EVCacheTracingTags.CANONICAL_KEY), "CANONICAL_KEY tag is missing");
+    Assert.assertTrue(tags.containsKey(EVCacheTracingTags.CANONICAL_KEYS), "CANONICAL_KEYS tag is missing");
     Assert.assertTrue(tags.containsKey(EVCacheTracingTags.STATUS), "STATUS tag is missing");
     Assert.assertTrue(tags.containsKey(EVCacheTracingTags.LATENCY), "LATENCY tag is missing");
     Assert.assertTrue(tags.containsKey(EVCacheTracingTags.DATA_TTL), "DATA_TTL tag is missing");


### PR DESCRIPTION
The EVCacheEvent::getEVCacheKeys() method returns multiple keys in case of bulk operation. It causes the tags to be overwritten by the last iterated key.

This PR fixes the the overwrite issue. Additionally, we are adding an optimization that records tags if tracing is enabled by checking `clientSpan.isNoop()`. 