### PR TITLE
Duet feature

### DIFF
--- a/evcache-core/src/main/java/com/netflix/evcache/EVCacheKey.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/EVCacheKey.java
@@ -3,25 +3,47 @@ package com.netflix.evcache;
 public class EVCacheKey {
     private final String key;
     private final String canonicalKey;
+    private final String canonicalKeyForDuet;
     private final String hashKey;
+    private final String hashKeyForDuet;
 
-    public EVCacheKey(String key, String canonicalKey, String hashKey) {
+    public EVCacheKey(String key, String canonicalKey, String canonicalKeyForDuet, String hashKey, String hashKeyForDuet) {
         super();
         this.key = key;
         this.canonicalKey = canonicalKey;
+        this.canonicalKeyForDuet = canonicalKeyForDuet;
         this.hashKey = hashKey;
+        this.hashKeyForDuet = hashKeyForDuet;
     }
 
     public String getKey() {
         return key;
     }
 
+    @Deprecated
     public String getCanonicalKey() {
         return canonicalKey;
     }
 
+    public String getCanonicalKey(boolean isDuet) {
+        return isDuet ? canonicalKeyForDuet : canonicalKey;
+    }
+
+    @Deprecated
     public String getHashKey() {
         return hashKey;
+    }
+
+    public String getHashKey(boolean isDuet) {
+        return isDuet ? hashKeyForDuet : hashKey;
+    }
+    
+    public String getDerivedKey(boolean isDuet)
+    {
+        if (isDuet)
+            return null == hashKeyForDuet ? canonicalKeyForDuet : hashKeyForDuet;
+
+        return null == hashKey ? canonicalKey : hashKey;
     }
 
     @Override
@@ -29,7 +51,9 @@ public class EVCacheKey {
         final int prime = 31;
         int result = 1;
         result = prime * result + ((canonicalKey == null) ? 0 : canonicalKey.hashCode());
+        result = prime * result + ((canonicalKeyForDuet == null) ? 0 : canonicalKeyForDuet.hashCode());
         result = prime * result + ((hashKey == null) ? 0 : hashKey.hashCode());
+        result = prime * result + ((hashKeyForDuet == null) ? 0 : hashKeyForDuet.hashCode());
         result = prime * result + ((key == null) ? 0 : key.hashCode());
         return result;
     }
@@ -48,10 +72,20 @@ public class EVCacheKey {
                 return false;
         } else if (!canonicalKey.equals(other.canonicalKey))
             return false;
+        if (canonicalKeyForDuet == null) {
+            if (other.canonicalKeyForDuet != null)
+                return false;
+        } else if (!canonicalKeyForDuet.equals(other.canonicalKeyForDuet))
+            return false;
         if (hashKey == null) {
             if (other.hashKey != null)
                 return false;
         } else if (!hashKey.equals(other.hashKey))
+            return false;
+        if (hashKeyForDuet == null) {
+            if (other.hashKeyForDuet != null)
+                return false;
+        } else if (!hashKeyForDuet.equals(other.hashKeyForDuet))
             return false;
         if (key == null) {
             if (other.key != null)
@@ -63,7 +97,7 @@ public class EVCacheKey {
 
     @Override
     public String toString() {
-        return "EVCacheKey [key=" + key + ", canonicalKey=" + canonicalKey + (hashKey != null ? ", hashKey=" + hashKey + "]" : "]");
+        return "EVCacheKey [key=" + key + ", canonicalKey=" + canonicalKey + ", canonicalKeyForDuet=" + canonicalKeyForDuet + (hashKey != null ? ", hashKey=" + hashKey : "") + (hashKeyForDuet != null ? ", hashKeyForDuet=" + hashKeyForDuet + "]" : "]");
     }
 
 }

--- a/evcache-core/src/main/java/com/netflix/evcache/event/EVCacheEvent.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/event/EVCacheEvent.java
@@ -170,7 +170,7 @@ public class EVCacheEvent {
     public Collection<MemcachedNode> getMemcachedNode(EVCacheKey evckey) {
         final Collection<MemcachedNode> nodeList = new ArrayList<MemcachedNode>(clients.size());
         for(EVCacheClient client : clients) {
-            String key = evckey.getHashKey() == null ? evckey.getCanonicalKey() : evckey.getHashKey();
+            String key = evckey.getDerivedKey(client.isDuetClient());
             nodeList.add(client.getNodeLocator().getPrimary(key));
         }
         return nodeList;

--- a/evcache-core/src/main/java/com/netflix/evcache/pool/EVCacheClient.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/pool/EVCacheClient.java
@@ -99,12 +99,13 @@ public class EVCacheClient {
     private final Map<String, Counter> counterMap = new ConcurrentHashMap<String, Counter>();
     private final Property<String> hashingAlgo;
     protected final Counter operationsCounter;
+    private final boolean isDuetClient;
 
     EVCacheClient(String appName, String zone, int id, EVCacheServerGroupConfig config,
             List<InetSocketAddress> memcachedNodesInZone, int maxQueueSize, Property<Integer> maxReadQueueSize,
                   Property<Integer> readTimeout, Property<Integer> bulkReadTimeout,
                   Property<Integer> opQueueMaxBlockTime,
-                  Property<Integer> operationTimeout, EVCacheClientPool pool) throws IOException {
+                  Property<Integer> operationTimeout, EVCacheClientPool pool, boolean isDuetClient) throws IOException {
         this.memcachedNodesInZone = memcachedNodesInZone;
         this.id = id;
         this.appName = appName;
@@ -116,6 +117,7 @@ public class EVCacheClient {
         this.maxReadQueueSize = maxReadQueueSize;
 //        this.operationTimeout = operationTimeout;
         this.pool = pool;
+        this.isDuetClient = isDuetClient;
 
         final List<Tag> tagList = new ArrayList<Tag>(4);
         EVCacheMetricsFactory.getInstance().addAppNameTags(tagList, appName);
@@ -146,9 +148,13 @@ public class EVCacheClient {
         this.evcacheValueTranscoder = new EVCacheTranscoder();
         evcacheValueTranscoder.setCompressionThreshold(Integer.MAX_VALUE);
 
-        this.hashKeyByApp = EVCacheConfig.getInstance().getPropertyRepository().get(appName + ".hash.key", Boolean.class).orElse(false);
+        this.hashKeyByApp = EVCacheConfig.getInstance().getPropertyRepository().get(appName + ".hash.key", Boolean.class).orElseGet(appName + ".auto.hash.keys").orElseGet("evcache.auto.hash.keys").orElse(false);
         this.hashKeyByServerGroup = EVCacheConfig.getInstance().getPropertyRepository().get(this.serverGroup.getName() + ".hash.key", Boolean.class).orElse(false);
         this.hashingAlgo = EVCacheConfig.getInstance().getPropertyRepository().get(this.serverGroup.getName() + ".hash.algo", String.class).orElseGet(appName + ".hash.algo").orElse("MD5");
+    }
+
+    public boolean isDuetClient() {
+        return isDuetClient;
     }
 
     private Collection<String> validateReadQueueSize(Collection<String> canonicalKeys, EVCache.Call call) throws EVCacheException {

--- a/evcache-core/src/main/java/com/netflix/evcache/pool/EVCacheClientPool.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/pool/EVCacheClientPool.java
@@ -58,6 +58,16 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
     private final Property<Set<String>> logOperationCalls;
     private final Property<Set<String>> cloneWrite;
 
+    // name of the duet EVCache application, if applicable.
+    private final Property<String> duet;
+    // evCacheClientPool of the duet EVCache application, if applicable. Supports daisy chaining.
+    private EVCacheClientPool duetClientPool;
+
+    // indicates if this evCacheClientPool is a duet. This property is used to mark EVCacheClients of this pool
+    // as duet if applicable. The duet property on the EVCacheClient is then used to know what kind of key of
+    // EVCacheKey (i.e. normal key vs duet key) should be passed to the client
+    private boolean isDuet;
+
     private final Property<Integer> _opQueueMaxBlockTime; // Timeout for adding an operation
     private final Property<Integer> _operationTimeout;// Timeout for write operation
     private final Property<Integer> _maxReadQueueSize;
@@ -106,11 +116,12 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
     private CircularIterator<EVCacheClient[]> allEVCacheWriteClients = new CircularIterator<EVCacheClient[]>(Collections.<EVCacheClient[]> emptyList());
     private final EVCacheNodeList provider;
 
-    EVCacheClientPool(final String appName, final EVCacheNodeList provider, final ThreadPoolExecutor asyncRefreshExecutor, final EVCacheClientPoolManager manager) {
+    EVCacheClientPool(final String appName, final EVCacheNodeList provider, final ThreadPoolExecutor asyncRefreshExecutor, final EVCacheClientPoolManager manager, boolean isDuet) {
         this._appName = appName;
         this.provider = provider;
         this.asyncRefreshExecutor = asyncRefreshExecutor;
         this.manager = manager;
+        this.isDuet = isDuet;
 
         String ec2Zone = System.getenv("EC2_AVAILABILITY_ZONE");
         if (ec2Zone == null) ec2Zone = System.getProperty("EC2_AVAILABILITY_ZONE");
@@ -149,6 +160,11 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
             setupClones();
         });
 
+        this.duet = config.getPropertyRepository().get(appName + ".duet", String.class).orElse("");
+        this.duet.subscribe(i -> {
+            setupDuet();
+        });
+
         tagList = new ArrayList<Tag>(2);
         EVCacheMetricsFactory.getInstance().addAppNameTags(tagList, _appName);
 
@@ -164,6 +180,10 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
     	}
     }
 
+    private void setupDuet() {
+        this.duetClientPool = manager.initEVCache(duet.get(), true);
+    }
+
     private void clearState() {
         cleanupMemcachedInstances(true);
         memcachedInstancesByServerGroup.clear();
@@ -173,7 +193,7 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
         memcachedFallbackReadInstances = new ServerGroupCircularIterator(Collections.<ServerGroup> emptySet());
     }
 
-    public EVCacheClient getEVCacheClientForRead() {
+    private EVCacheClient getEVCacheClientForReadInternal() {
         if (memcachedReadInstancesByServerGroup == null || memcachedReadInstancesByServerGroup.isEmpty()) {
             if (log.isDebugEnabled()) log.debug("memcachedReadInstancesByServerGroup : " + memcachedReadInstancesByServerGroup);
             //refreshPool(true, true);
@@ -201,7 +221,21 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
         }
     }
 
-    public List<EVCacheClient> getAllEVCacheClientForRead() {
+    /**
+     * Returns EVCacheClient of this pool if available. Otherwise, will return EVCacheClient of the duet.
+     * @return
+     */
+    public EVCacheClient getEVCacheClientForRead() {
+        EVCacheClient evCacheClient = getEVCacheClientForReadInternal();
+
+        if (evCacheClient != null) {
+            return evCacheClient;
+        }
+
+        return duetClientPool != null ? duetClientPool.getEVCacheClientForRead() : null;
+    }
+
+    private List<EVCacheClient> getAllEVCacheClientForReadInternal() {
         if (memcachedReadInstancesByServerGroup == null || memcachedReadInstancesByServerGroup.isEmpty()) {
             if (log.isDebugEnabled()) log.debug("memcachedReadInstancesByServerGroup : " + memcachedReadInstancesByServerGroup);
             //if(asyncRefreshExecutor.getQueue().isEmpty()) refreshPool(true, true);
@@ -229,6 +263,21 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
         }
     }
 
+    public List<EVCacheClient> getAllEVCacheClientForRead() {
+        List<EVCacheClient> evCacheClients = getAllEVCacheClientForReadInternal();
+        if (duetClientPool != null) {
+            List<EVCacheClient> duetEVCacheClients = duetClientPool.getAllEVCacheClientForRead();
+            if (null == evCacheClients)
+                return duetEVCacheClients;
+
+            if (null == duetEVCacheClients)
+                return evCacheClients;
+
+            evCacheClients.addAll(duetClientPool.getAllEVCacheClientForRead());
+        }
+        return evCacheClients;
+    }
+
     private EVCacheClient selectClient(List<EVCacheClient> clients) {
         if (clients == null || clients.isEmpty()) {
             if (log.isDebugEnabled()) log.debug("clients is null returning null and forcing pool refresh!!!");
@@ -246,7 +295,7 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
         return clients.get(index);
     }
 
-    public EVCacheClient getEVCacheClientForReadExclude(ServerGroup rsetUsed) {
+    private EVCacheClient getEVCacheClientForReadExcludeInternal(ServerGroup rsetUsed) {
         if (memcachedReadInstancesByServerGroup == null || memcachedReadInstancesByServerGroup.isEmpty()) {
             if (log.isDebugEnabled()) log.debug("memcachedReadInstancesByServerGroup : " + memcachedReadInstancesByServerGroup);
             //if(asyncRefreshExecutor.getQueue().isEmpty()) refreshPool(true, true);
@@ -265,7 +314,17 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
         }
     }
 
-    public EVCacheClient getEVCacheClient(ServerGroup serverGroup) {
+    public EVCacheClient getEVCacheClientForReadExclude(ServerGroup rsetUsed) {
+        EVCacheClient evCacheClient = getEVCacheClientForReadExcludeInternal(rsetUsed);
+
+        if (evCacheClient != null) {
+            return evCacheClient;
+        }
+
+        return duetClientPool != null ? duetClientPool.getEVCacheClientForReadExclude(rsetUsed) : null;
+    }
+
+    private EVCacheClient getEVCacheClientInternal(ServerGroup serverGroup) {
         if (memcachedReadInstancesByServerGroup == null || memcachedReadInstancesByServerGroup.isEmpty()) {
             if (log.isDebugEnabled()) log.debug("memcachedReadInstancesByServerGroup : " + memcachedReadInstancesByServerGroup);
             //if(asyncRefreshExecutor.getQueue().isEmpty()) refreshPool(true, true);
@@ -289,7 +348,17 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
         }
     }
 
-    public List<EVCacheClient> getEVCacheClientsForReadExcluding(ServerGroup serverGroupToExclude) {
+    public EVCacheClient getEVCacheClient(ServerGroup serverGroup) {
+        EVCacheClient evCacheClient = getEVCacheClientInternal(serverGroup);
+
+        if (evCacheClient != null) {
+            return evCacheClient;
+        }
+
+        return duetClientPool != null ? duetClientPool.getEVCacheClient(serverGroup) : null;
+    }
+
+    private List<EVCacheClient> getEVCacheClientsForReadExcludingInternal(ServerGroup serverGroupToExclude) {
         if (memcachedReadInstancesByServerGroup == null || memcachedReadInstancesByServerGroup.isEmpty()) {
             if (log.isDebugEnabled()) log.debug("memcachedReadInstancesByServerGroup : " + memcachedReadInstancesByServerGroup);
             //if(asyncRefreshExecutor.getQueue().isEmpty()) refreshPool(true, true);
@@ -337,6 +406,21 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
         return Collections.<EVCacheClient> emptyList();
     }
 
+    public List<EVCacheClient> getEVCacheClientsForReadExcluding(ServerGroup serverGroupToExclude) {
+        List<EVCacheClient> evCacheClients = getEVCacheClientsForReadExcludingInternal(serverGroupToExclude);
+        if (duetClientPool != null) {
+            List<EVCacheClient> duetEVCacheClients = duetClientPool.getEVCacheClientsForReadExcluding(serverGroupToExclude);
+            if (null == evCacheClients)
+                return duetEVCacheClients;
+
+            if (null == duetEVCacheClients)
+                return evCacheClients;
+
+            evCacheClients.addAll(duetClientPool.getEVCacheClientsForReadExcluding(serverGroupToExclude));
+        }
+        return evCacheClients;
+    }
+
     public boolean isInWriteOnly(ServerGroup serverGroup) {
           if (memcachedReadInstancesByServerGroup.containsKey(serverGroup)) {
               return false;
@@ -347,7 +431,7 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
           return false;
     }
 
-    public EVCacheClient[] getWriteOnlyEVCacheClients() {
+    private EVCacheClient[] getWriteOnlyEVCacheClientsInternal() {
         try {
             if((cloneWrite.get().size() == 0)) {
                 int size = memcachedWriteInstancesByServerGroup.size() - memcachedReadInstancesByServerGroup.size();
@@ -395,6 +479,25 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
         }
     }
 
+    public EVCacheClient[] getWriteOnlyEVCacheClients() {
+        EVCacheClient[] evCacheClients = getWriteOnlyEVCacheClientsInternal();
+        if (duetClientPool != null) {
+            EVCacheClient[] duetEVCacheClients = duetClientPool.getWriteOnlyEVCacheClients();
+
+            // common scenario for duet usage
+            if (null == evCacheClients || evCacheClients.length == 0) {
+                return duetEVCacheClients;
+            }
+
+            if (null != duetEVCacheClients && duetEVCacheClients.length > 0) {
+                EVCacheClient[] allEVCacheClients = Arrays.copyOf(evCacheClients, evCacheClients.length + duetEVCacheClients.length);
+                System.arraycopy(duetEVCacheClients, 0, allEVCacheClients, evCacheClients.length, duetEVCacheClients.length);
+                return allEVCacheClients;
+            }
+        }
+        return evCacheClients;
+    }
+
     EVCacheClient[] getAllWriteClients() {
         try {
             if(allEVCacheWriteClients != null) {
@@ -436,7 +539,7 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
     }
 
 
-    public EVCacheClient[] getEVCacheClientForWrite() {
+    private EVCacheClient[] getEVCacheClientForWriteInternal() {
         try {
             if((cloneWrite.get().size() == 0)) {
                 return getAllWriteClients();
@@ -458,6 +561,25 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
             log.error("Exception trying to get an array of writable EVCache Instances", t);
             return new EVCacheClient[0];
         }
+    }
+
+    public EVCacheClient[] getEVCacheClientForWrite() {
+        EVCacheClient[] evCacheClients = getEVCacheClientForWriteInternal();
+        if (duetClientPool != null) {
+            EVCacheClient[] duetEVCacheClients = duetClientPool.getEVCacheClientForWrite();
+
+            // common scenario for duet usage
+            if (null == evCacheClients || evCacheClients.length == 0) {
+                return duetEVCacheClients;
+            }
+
+            if (null != duetEVCacheClients && duetEVCacheClients.length > 0) {
+                EVCacheClient[] allEVCacheClients = Arrays.copyOf(evCacheClients, evCacheClients.length + duetEVCacheClients.length);
+                System.arraycopy(duetEVCacheClients, 0, allEVCacheClients, evCacheClients.length, duetEVCacheClients.length);
+                return allEVCacheClients;
+            }
+        }
+        return evCacheClients;
     }
 
     private void refresh() throws IOException {
@@ -842,7 +964,7 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
                         EVCacheClient client;
                         try {
                             client = new EVCacheClient(_appName, zone, i, config, memcachedSAInServerGroup, maxQueueSize,
-                            		_maxReadQueueSize, _readTimeout, _bulkReadTimeout, _opQueueMaxBlockTime, _operationTimeout, this);
+                            		_maxReadQueueSize, _readTimeout, _bulkReadTimeout, _opQueueMaxBlockTime, _operationTimeout, this, isDuet);
                             newClients.add(client);
                             final int id = client.getId();
                             if (log.isDebugEnabled()) log.debug("AppName :" + _appName + "; ServerGroup : " + serverGroup + "; intit : client.getId() : " + id);
@@ -943,6 +1065,9 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
                     }
                 }
             }
+
+            if (duetClientPool != null)
+                duetClientPool.pingServers();
         } catch (Throwable t) {
             log.error("Error while pinging the servers", t);
         }
@@ -963,6 +1088,8 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
                 client.getConnectionObserver().shutdown();
             }
         }
+        if (duetClientPool != null)
+            duetClientPool.serverGroupDisabled(serverGroup);
     }
 
     public void refreshAsync(MemcachedNode node) {
@@ -976,6 +1103,8 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
             if(!force) force = !node.isActive();
             refreshPool(true, force);
         }
+        if (duetClientPool != null)
+            duetClientPool.refreshAsync(node);
     }
 
     public void run() {
@@ -1099,6 +1228,10 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
         for (ServerGroup serverGroup : memcachedInstancesByServerGroup.keySet()) {
             instances += memcachedInstancesByServerGroup.get(serverGroup).get(0).getConnectionObserver().getActiveServerCount();
         }
+
+        if (duetClientPool != null)
+            instances += duetClientPool.getInstanceCount();
+
         return instances;
     }
 
@@ -1108,6 +1241,10 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
             final List<EVCacheClient> instanceList = memcachedInstancesByServerGroup.get(zone);
             instanceMap.put(zone.toString(), instanceList.toString());
         }
+
+        if (duetClientPool != null)
+            instanceMap.putAll(duetClientPool.getInstancesByZone());
+
         return instanceMap;
     }
 
@@ -1116,6 +1253,10 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
         for (ServerGroup zone : memcachedInstancesByServerGroup.keySet()) {
             instancesByZone.put(zone.getName(), Integer.valueOf(memcachedInstancesByServerGroup.get(zone).get(0).getConnectionObserver().getActiveServerCount()));
         }
+
+        if (duetClientPool != null)
+            instancesByZone.putAll(duetClientPool.getInstanceCountByZone());
+
         return instancesByZone;
     }
 
@@ -1124,6 +1265,10 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
         for (ServerGroup key : memcachedReadInstancesByServerGroup.keySet()) {
             instanceMap.put(key.getName(), memcachedReadInstancesByServerGroup.get(key).toString());
         }
+
+        if (duetClientPool != null)
+            instanceMap.putAll(duetClientPool.getReadZones());
+
         return instanceMap;
     }
 
@@ -1133,6 +1278,10 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
             instanceMap.put(key.getName(), Integer.valueOf(memcachedReadInstancesByServerGroup.get(key).get(0)
                     .getConnectionObserver().getActiveServerCount()));
         }
+
+        if (duetClientPool != null)
+            instanceMap.putAll(duetClientPool.getReadInstanceCountByZone());
+
         return instanceMap;
     }
 
@@ -1141,18 +1290,44 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
         for (ServerGroup key : memcachedWriteInstancesByServerGroup.keySet()) {
             instanceMap.put(key.toString(), memcachedWriteInstancesByServerGroup.get(key).toString());
         }
+
+        if (duetClientPool != null)
+            instanceMap.putAll(duetClientPool.getWriteZones());
+
         return instanceMap;
     }
 
-    public Map<ServerGroup, List<EVCacheClient>> getAllInstancesByZone() {
+    private Map<ServerGroup, List<EVCacheClient>> getAllInstancesByZoneInternal() {
         return Collections.unmodifiableMap(memcachedInstancesByServerGroup);
     }
 
-    Map<ServerGroup, List<EVCacheClient>> getAllInstancesByServerGroup() {
+    public Map<ServerGroup, List<EVCacheClient>> getAllInstancesByZone() {
+        if (duetClientPool != null) {
+            Map<ServerGroup, List<EVCacheClient>> allInstanceMap = new ConcurrentHashMap<>();
+            allInstanceMap.putAll(getAllInstancesByZoneInternal());
+            allInstanceMap.putAll(duetClientPool.getAllInstancesByZone());
+            return Collections.unmodifiableMap(allInstanceMap);
+        }
+
+        return getAllInstancesByZoneInternal();
+    }
+
+    Map<ServerGroup, List<EVCacheClient>> getAllInstancesByServerGroupInternal() {
         return memcachedInstancesByServerGroup;
     }
 
-    public Map<String, Integer> getWriteInstanceCountByZone() {
+    public Map<ServerGroup, List<EVCacheClient>> getAllInstancesByServerGroup() {
+        if (duetClientPool == null) {
+            return getAllInstancesByServerGroupInternal();
+        }
+
+        Map<ServerGroup, List<EVCacheClient>> allInstancesByServerGroup = new ConcurrentHashMap<>();
+        allInstancesByServerGroup.putAll(getAllInstancesByServerGroupInternal());
+        allInstancesByServerGroup.putAll(duetClientPool.getAllInstancesByServerGroup());
+        return allInstancesByServerGroup;
+    }
+
+    private Map<String, Integer> getWriteInstanceCountByZoneInternal() {
         final Map<String, Integer> instanceMap = new HashMap<String, Integer>();
         for (ServerGroup key : memcachedWriteInstancesByServerGroup.keySet()) {
             instanceMap.put(key.toString(), Integer.valueOf(memcachedWriteInstancesByServerGroup.get(key).get(0).getConnectionObserver().getActiveServerCount()));
@@ -1160,7 +1335,15 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
         return instanceMap;
     }
 
-    public Map<String, String> getReadServerGroupByZone() {
+    public Map<String, Integer> getWriteInstanceCountByZone() {
+        Map<String, Integer> instanceMap = getWriteInstanceCountByZoneInternal();
+        if (duetClientPool != null)
+            instanceMap.putAll(duetClientPool.getWriteInstanceCountByZone());
+
+        return instanceMap;
+    }
+
+    private Map<String, String> getReadServerGroupByZoneInternal() {
         final Map<String, String> instanceMap = new HashMap<String, String>();
         for (String key : readServerGroupByZone.keySet()) {
             instanceMap.put(key, readServerGroupByZone.get(key).toString());
@@ -1168,8 +1351,19 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
         return instanceMap;
     }
 
+    public Map<String, String> getReadServerGroupByZone() {
+        Map<String, String> instanceMap = getReadServerGroupByZoneInternal();
+        if (duetClientPool != null)
+            instanceMap.putAll(duetClientPool.getReadServerGroupByZone());
+
+        return instanceMap;
+    }
+
     public void refreshPool() {
         refreshPool(false, true);
+
+        if (duetClientPool != null)
+            duetClientPool.refreshPool(false, true);
     }
 
     public void refreshPool(boolean async, boolean force) {
@@ -1192,14 +1386,20 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
         } catch (Throwable t) {
             if (log.isDebugEnabled()) log.debug("Error Refreshing EVCache Instance list from MBean : " + _appName, t);
         }
+
+        if (duetClientPool != null)
+            duetClientPool.refreshPool(async, force);
     }
 
     public String getFallbackServerGroup() {
-        return memcachedFallbackReadInstances.toString();
+        if (memcachedFallbackReadInstances.getSize() != 0 || duetClientPool == null)
+            return memcachedFallbackReadInstances.toString();
+
+        return duetClientPool.getFallbackServerGroup();
     }
 
     public boolean supportsFallback() {
-        return memcachedFallbackReadInstances.getSize() > 1;
+        return memcachedFallbackReadInstances.getSize() > 1 || (duetClientPool != null && duetClientPool.supportsFallback());
     }
 
     public boolean isLogEventEnabled() {
@@ -1214,12 +1414,12 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
 
     @Override
     public String getLocalServerGroupCircularIterator() {
-        return (localServerGroupIterator == null) ? "NONE" : localServerGroupIterator.toString();
+        return (localServerGroupIterator == null) ? (duetClientPool == null ? "NONE" : duetClientPool.getLocalServerGroupCircularIterator()) : localServerGroupIterator.toString();
     }
 
     @Override
     public String getEVCacheWriteClientsCircularIterator() {
-        return (allEVCacheWriteClients == null) ? "NONE" : allEVCacheWriteClients.toString();
+        return (allEVCacheWriteClients == null) ? (duetClientPool == null ? "NONE" : duetClientPool.getEVCacheWriteClientsCircularIterator()) : allEVCacheWriteClients.toString();
     }
 
     public String getPoolDetails() {
@@ -1237,11 +1437,11 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
             + ",\n\tmemcachedWriteInstancesByServerGroup=" + memcachedWriteInstancesByServerGroup + ",\n\treadServerGroupByZone=" + readServerGroupByZone
             + ",\n\tmemcachedFallbackReadInstances=" + memcachedFallbackReadInstances + "\n]"
             + ", \n\tallEVCacheWriteClients=" + allEVCacheWriteClients
-            + "\n]";
+            + "\n]" + (duetClientPool == null ? "" : duetClientPool.toString());
     }
 
     public int getPoolSize() {
-        return _poolSize.get();
+        return _poolSize.get() + (duetClientPool == null ? 0 : duetClientPool.getPoolSize());
     }
 
     public Property<Integer> getLogOperations() {
@@ -1285,6 +1485,12 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
     }
 
     public Map<ServerGroup, Property<Boolean>> getWriteOnlyFastPropertyMap() {
+        if (duetClientPool != null) {
+            Map<ServerGroup, Property<Boolean>> allMap = new ConcurrentHashMap<>();
+            allMap.putAll(writeOnlyFastPropertyMap);
+            allMap.putAll(duetClientPool.getWriteOnlyFastPropertyMap());
+            return Collections.unmodifiableMap(allMap);
+        }
         return Collections.unmodifiableMap(writeOnlyFastPropertyMap);
     }
 
@@ -1297,6 +1503,8 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
     }
 
     /*
+     * This method is helpful in cases where there is typically a large backlog of work queued up, and is
+     * expensive to loose all that work when a client is shut down.
      * Block the thread until all the queues are processed or at most 30 seconds.
      * Will return the count of items left in the queues. 0 means none left.
      */
@@ -1304,7 +1512,7 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
         int size = 0;
         int counter = 0;
         do {
-            for(List<EVCacheClient> clientList : memcachedInstancesByServerGroup.values()) {
+            for(List<EVCacheClient> clientList : getAllInstancesByServerGroup().values()) {
                 for(EVCacheClient client : clientList) {
                     size +=client.getWriteQueueLength();
                     size +=client.getReadQueueLength();

--- a/evcache-core/src/main/java/com/netflix/evcache/pool/EVCacheClientPoolManager.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/pool/EVCacheClientPoolManager.java
@@ -178,13 +178,17 @@ public class EVCacheClientPoolManager {
      * @param app
      *            - name of the evcache app
      */
-    public final synchronized void initEVCache(String app) {
+    public final synchronized EVCacheClientPool initEVCache(String app) {
+        return initEVCache(app, false);
+    }
+    public final synchronized EVCacheClientPool initEVCache(String app, boolean isDuet) {
         if (app == null || (app = app.trim()).length() == 0) throw new IllegalArgumentException("param app name null or space");
         final String APP = getAppName(app);
-        if (poolMap.containsKey(APP)) return;
-        final EVCacheClientPool pool = new EVCacheClientPool(APP, evcacheNodeList, asyncExecutor, this);
+        if (poolMap.containsKey(APP)) return poolMap.get(APP);
+        final EVCacheClientPool pool = new EVCacheClientPool(APP, evcacheNodeList, asyncExecutor, this, isDuet);
         scheduleRefresh(pool);
         poolMap.put(APP, pool);
+        return pool;
     }
 
     private void scheduleRefresh(EVCacheClientPool pool) {

--- a/evcache-core/src/main/java/com/netflix/evcache/pool/EVCacheClientUtil.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/pool/EVCacheClientUtil.java
@@ -3,6 +3,8 @@ package com.netflix.evcache.pool;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import com.netflix.evcache.EVCacheKey;
+import net.spy.memcached.transcoders.Transcoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,7 +28,7 @@ public class EVCacheClientUtil {
     /**
      * TODO : once metaget is available we need to get the remaining ttl from an existing entry and use it 
      */
-    public EVCacheLatch add(String canonicalKey, CachedData cd, int timeToLive, Policy policy) throws Exception {
+    public EVCacheLatch add(EVCacheKey evcKey, CachedData cd, boolean shouldHashKey, Transcoder evcacheValueTranscoder, int timeToLive, Policy policy) throws Exception {
         if (cd == null) return null; 
         
         final EVCacheClient[] clients = _pool.getEVCacheClientForWrite();
@@ -34,8 +36,13 @@ public class EVCacheClientUtil {
 
         Boolean firstStatus = null;
         for (EVCacheClient client : clients) {
-            final Future<Boolean> f = client.add(canonicalKey, timeToLive, cd, latch);
-            if(log.isDebugEnabled()) log.debug("ADD : Op Submitted : APP " + _appName + ", key " + canonicalKey + "; future : " + f + "; client : " + client);
+            String key = evcKey.getDerivedKey(client.isDuetClient());
+            if (shouldHashKey) {
+                final EVCacheValue val = new EVCacheValue(evcKey.getCanonicalKey(client.isDuetClient()), cd.getData(), cd.getFlags(), timeToLive, System.currentTimeMillis());
+                cd = evcacheValueTranscoder.encode(val);
+            }
+            final Future<Boolean> f = client.add(key, timeToLive, cd, latch);
+            if (log.isDebugEnabled()) log.debug("ADD : Op Submitted : APP " + _appName + ", key " + key + "; future : " + f + "; client : " + client);
             boolean status = f.get().booleanValue();
             if(!status) { // most common case
                 if(firstStatus == null) {
@@ -44,7 +51,7 @@ public class EVCacheClientUtil {
                     }
                     return latch;
                 } else {
-                    return fixup(client, clients, canonicalKey, timeToLive, policy);
+                    return fixup(client, clients, evcKey, timeToLive, policy);
                 }
             }
             if(firstStatus == null) firstStatus = Boolean.valueOf(status);
@@ -52,14 +59,14 @@ public class EVCacheClientUtil {
         return latch;
     }
 
-    private EVCacheLatch fixup(EVCacheClient sourceClient, EVCacheClient[] destClients, String canonicalKey, int timeToLive, Policy policy) {
+    private EVCacheLatch fixup(EVCacheClient sourceClient, EVCacheClient[] destClients, EVCacheKey evcKey, int timeToLive, Policy policy) {
         final EVCacheLatchImpl latch = new EVCacheLatchImpl(policy, destClients.length, _appName);
         try {
-            final CachedData readData = sourceClient.getAndTouch(canonicalKey, ct, timeToLive, false, false);
+            final CachedData readData = sourceClient.getAndTouch(evcKey.getDerivedKey(sourceClient.isDuetClient()), ct, timeToLive, false, false);
 
             if(readData != null) {
                 for(EVCacheClient destClient : destClients) {
-                    destClient.set(canonicalKey, readData, timeToLive, latch);
+                    destClient.set(evcKey.getDerivedKey(destClient.isDuetClient()), readData, timeToLive, latch);
                 }
             }
             latch.await(_pool.getOperationTimeout().get(), TimeUnit.MILLISECONDS);

--- a/evcache-zipkin-tracing/src/test/java/com/netflix/evcache/EVCacheTracingEventListenerUnitTests.java
+++ b/evcache-zipkin-tracing/src/test/java/com/netflix/evcache/EVCacheTracingEventListenerUnitTests.java
@@ -40,7 +40,7 @@ public class EVCacheTracingEventListenerUnitTests {
     when(mockEVCacheEvent.getAppName()).thenReturn("dummyAppName");
     when(mockEVCacheEvent.getCacheName()).thenReturn("dummyCacheName");
     when(mockEVCacheEvent.getEVCacheKeys())
-        .thenReturn(Arrays.asList(new EVCacheKey("dummyKey", "dummyCanonicalKey", null)));
+        .thenReturn(Arrays.asList(new EVCacheKey("dummyKey", "dummyCanonicalKey", "dummyCanonicalKeyForDuet", null, null)));
     when(mockEVCacheEvent.getStatus()).thenReturn("success");
     when(mockEVCacheEvent.getDurationInMillis()).thenReturn(1L);
     when(mockEVCacheEvent.getTTL()).thenReturn(0);


### PR DESCRIPTION
An EVCache server can be set an optional "Duet", where in, if set, every write operation from the client to the current evcache server, is also applied on the duet evcache server. As for reads, only if the current evcache server cannot serve the request, will the duet evcache server tries to serve the request.
Daisy chaining is supported. As in, Server1 can have a duet of Server 2, and Server 2 can have a duet of Server 3, so any operations on Server1 apply to Server2 and Server3 as well, and any operations on Server2 apply on Server3 as well.