### PR TITLE
Specify an exact brave version instead of latest.release

### DIFF
--- a/evcache-zipkin-tracing/build.gradle
+++ b/evcache-zipkin-tracing/build.gradle
@@ -10,7 +10,7 @@ repositories {
 
 dependencies {
     compile project(':evcache-core')
-    compile group:"io.zipkin.brave", name:"brave", version:"latest.release"
+    compile group:"io.zipkin.brave", name:"brave", version:"5.10.1"
     testCompile group:"org.testng", name:"testng", version:"7.+"
     testCompile group:"org.mockito", name:"mockito-all", version:"latest.release"
 }


### PR DESCRIPTION
Specifying latest release will bump the brave version for dependent libraries/apps. i.e. currently spring-sleuth-core 2.2.2 is not compatible with latest version of brave.
Specifying the exact version will allow the version resolution to use higher versions if other transitives require so. 