### PR TITLE
Consolidating hashing to Impl, and removing hashing from EVCacheClient

### DIFF
--- a/evcache-client/test/com/netflix/evcache/test/EVCacheTestDI.java
+++ b/evcache-client/test/com/netflix/evcache/test/EVCacheTestDI.java
@@ -5,21 +5,33 @@ import static org.testng.Assert.assertTrue;
 
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.Future;
 
+import java.util.*;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import com.netflix.evcache.EVCache;
+import com.netflix.evcache.EVCacheException;
+import com.netflix.evcache.EVCacheLatch;
+import com.netflix.evcache.pool.EVCacheClient;
+import com.netflix.evcache.pool.ServerGroup;
+import com.netflix.evcache.util.KeyHasher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
-import com.netflix.evcache.EVCache;
 import com.netflix.evcache.EVCacheGetOperationListener;
 import com.netflix.evcache.operation.EVCacheOperationFuture;
-
 import rx.schedulers.Schedulers;
+
+
+import static org.testng.Assert.*;
 
 public class EVCacheTestDI extends DIBase implements EVCacheGetOperationListener<String> {
     private static final Logger log = LoggerFactory.getLogger(EVCacheTestDI.class);
     private int loops = 1;
+    private Map<String, String> propertiesToSet;
+    private String appName = "EVCACHE_TEST";
 
     public static void main(String args[]) {
         try {
@@ -31,31 +43,32 @@ public class EVCacheTestDI extends DIBase implements EVCacheGetOperationListener
     }
 
     public EVCacheTestDI() {
+        propertiesToSet = new HashMap<>();
+        propertiesToSet.putIfAbsent(appName + ".us-east-1d.EVCacheClientPool.writeOnly", "false");
+        propertiesToSet.putIfAbsent(appName + ".EVCacheClientPool.poolSize", "1");
+        propertiesToSet.putIfAbsent(appName + ".ping.servers", "false");
+        propertiesToSet.putIfAbsent(appName + ".cid.throw.exception", "true");
+        propertiesToSet.putIfAbsent(appName + ".EVCacheClientPool.readTimeout", "500");
+        propertiesToSet.putIfAbsent(appName + ".EVCacheClientPool.bulkReadTimeout", "500");
+        propertiesToSet.putIfAbsent(appName + ".max.read.queue.length", "20");
+        propertiesToSet.putIfAbsent("EVCacheClientPoolManager.log.apps", appName);
+        propertiesToSet.putIfAbsent(appName + ".fallback.zone", "true");
+        propertiesToSet.putIfAbsent(appName + ".enable.throttling", "false");
+        propertiesToSet.putIfAbsent(appName + ".throttle.time", "0");
+        propertiesToSet.putIfAbsent(appName + ".throttle.percent", "0");
+        propertiesToSet.putIfAbsent(appName + ".log.operation", "1000");
+        propertiesToSet.putIfAbsent(appName + ".EVCacheClientPool.validate.input.queue", "true");
     }
 
     protected Properties getProps() {
         Properties props = super.getProps();
-        props.setProperty("EVCACHE_CCS.us-east-1d.EVCacheClientPool.writeOnly", "false");
-        props.setProperty("EVCACHE_CCS.EVCacheClientPool.poolSize", "1");
-        props.setProperty("EVCACHE_CCS.ping.servers", "false");
-        props.setProperty("EVCACHE_CCS.cid.throw.exception", "true");
-        props.setProperty("EVCACHE_CCS.EVCacheClientPool.readTimeout", "500");
-        props.setProperty("EVCACHE_CCS.EVCacheClientPool.bulkReadTimeout", "500");
-        props.setProperty("EVCACHE_CCS.max.read.queue.length", "20");
-        props.setProperty("EVCacheClientPoolManager.log.apps", "EVCACHE_CCS");
-        props.setProperty("EVCACHE_CCS.fallback.zone", "true");
-        props.setProperty("EVCACHE_CCS.enable.throttling", "false");
-        props.setProperty("EVCACHE_CCS.throttle.time", "0");
-        props.setProperty("EVCACHE_CCS.throttle.percent", "0");
-        props.setProperty("EVCACHE_CCS.log.operation", "1000");
-        props.setProperty("EVCACHE_CCS.EVCacheClientPool.validate.input.queue", "true");
-
+        propertiesToSet.entrySet().forEach(entry -> props.setProperty(entry.getKey(), entry.getValue()));
         return props;
     }
 
     @Test
     public void testEVCache() {
-        this.evCache = getNewBuilder().setAppName("EVCACHE_CCS").setCachePrefix("cid").enableRetry().build();
+        this.evCache = getNewBuilder().setAppName(appName).setCachePrefix("cid").enableRetry().build();
         assertNotNull(evCache);
     }
 
@@ -86,7 +99,7 @@ public class EVCacheTestDI extends DIBase implements EVCacheGetOperationListener
             }
             assertTrue(exceptionThrown);
         }
-        
+
     }
 
     @Test(dependsOnMethods = { "testKeySizeCheck" })
@@ -239,6 +252,177 @@ public class EVCacheTestDI extends DIBase implements EVCacheGetOperationListener
         for (int i = 0; i < loops; i++) {
             assertTrue(appendOrAdd(i, evCache));
         }
+    }
+
+    private void refreshEVCache() {
+        setupEnv();
+        testEVCache();
+    }
+
+    @Test(dependsOnMethods = {"testAppendOrAdd"})
+    public void functionalTestsWithAppLevelAndASGLevelHashingScenarios() throws Exception {
+        // no hashing
+        assertFalse(manager.getEVCacheConfig().getPropertyRepository().get(appName + ".hash.key", Boolean.class).orElse(false).get());
+        doFunctionalTests(false);
+
+        // hashing at app level
+        propertiesToSet.put(appName + ".hash.key", "true");
+        refreshEVCache();
+        assertTrue(manager.getEVCacheConfig().getPropertyRepository().get(appName + ".hash.key", Boolean.class).orElse(false).get());
+        doFunctionalTests(true);
+        propertiesToSet.remove(appName + ".hash.key");
+
+        // hashing at app level due to auto hashing as a consequence of a large key
+        propertiesToSet.put(appName + ".auto.hash.keys", "true");
+        refreshEVCache();
+        assertTrue(manager.getEVCacheConfig().getPropertyRepository().get(appName + ".auto.hash.keys", Boolean.class).orElse(false).get());
+        assertFalse(manager.getEVCacheConfig().getPropertyRepository().get(appName + ".hash.key", Boolean.class).orElse(false).get());
+        testWithLargeKey();
+        // negative scenario
+        propertiesToSet.remove(appName + ".auto.hash.keys");
+        refreshEVCache();
+        assertFalse(manager.getEVCacheConfig().getPropertyRepository().get(appName + ".auto.hash.keys", Boolean.class).orElse(false).get());
+        assertFalse(manager.getEVCacheConfig().getPropertyRepository().get(appName + ".hash.key", Boolean.class).orElse(false).get());
+        assertThrows(IllegalArgumentException.class, () -> {
+            testWithLargeKey();
+        });
+
+        // hashing at app level by choice AND different hashing at each asg
+        Map<String, KeyHasher.HashingAlgorithm> hashingAlgorithmsByServerGroup = new HashMap<>();
+        propertiesToSet.put(appName + ".hash.key", "true");
+        refreshEVCache();
+        assertTrue(manager.getEVCacheConfig().getPropertyRepository().get(appName + ".hash.key", Boolean.class).orElse(false).get());
+
+        // get server group names, to be used to configure the ASG level hashing properties
+        Map<ServerGroup, List<EVCacheClient>> clientsByServerGroup = manager.getEVCacheClientPool(appName).getAllInstancesByServerGroup();
+        int i = 0;
+        for (ServerGroup serverGroup : clientsByServerGroup.keySet()) {
+            KeyHasher.HashingAlgorithm hashingAlgorithm = KeyHasher.HashingAlgorithm.values()[i++ % KeyHasher.HashingAlgorithm.values().length];
+            hashingAlgorithmsByServerGroup.put(serverGroup.getName(), hashingAlgorithm);
+            propertiesToSet.put(serverGroup.getName() + ".hash.key", "true");
+            propertiesToSet.put(serverGroup.getName() + ".hash.algo", hashingAlgorithm.name());
+        }
+        refreshEVCache();
+        clientsByServerGroup = manager.getEVCacheClientPool(appName).getAllInstancesByServerGroup();
+        // validate hashing properties of asgs
+        for (ServerGroup serverGroup : clientsByServerGroup.keySet()) {
+            assertEquals(clientsByServerGroup.get(serverGroup).get(0).getHashingAlgorithm(), hashingAlgorithmsByServerGroup.get(serverGroup.getName()));
+        }
+        doFunctionalTests(true);
+        for (ServerGroup serverGroup : clientsByServerGroup.keySet()) {
+            propertiesToSet.remove(serverGroup.getName());
+        }
+    }
+
+    private void testWithLargeKey() throws Exception {
+        StringBuilder sb = new StringBuilder();
+        for (int i= 0; i < 100; i++) {
+            sb.append(Long.toString(System.currentTimeMillis()));
+        }
+        String key = sb.toString();
+        String value = UUID.randomUUID().toString();
+
+        // set
+        EVCacheLatch latch = evCache.set(key, value, EVCacheLatch.Policy.ALL);
+        latch.await(1000, TimeUnit.MILLISECONDS);
+
+        // get
+        assertEquals(evCache.get(key), value);
+    }
+
+    private void doFunctionalTests(boolean isHashingEnabled) throws Exception {
+        String key1 = Long.toString(System.currentTimeMillis());
+        String value1 = UUID.randomUUID().toString();
+
+        // set
+        EVCacheLatch latch = evCache.set(key1, value1, EVCacheLatch.Policy.ALL);
+        latch.await(1000, TimeUnit.MILLISECONDS);
+
+        // get
+        assertEquals(evCache.get(key1), value1);
+
+        // replace
+        value1 = UUID.randomUUID().toString();
+        latch = evCache.replace(key1, value1, EVCacheLatch.Policy.ALL);
+        latch.await(1000, TimeUnit.MILLISECONDS);
+        // get
+        assertEquals(evCache.get(key1), value1);
+
+        // add a key
+        String key2 = Long.toString(System.currentTimeMillis());
+        String value2 = UUID.randomUUID().toString();
+        latch = evCache.add(key2, value2, null, 1000, EVCacheLatch.Policy.ALL);
+        latch.await(1000, TimeUnit.MILLISECONDS);
+        // get
+        assertEquals(evCache.get(key2), value2);
+
+        // appendoradd - append case
+        String value3 = UUID.randomUUID().toString();
+        if (isHashingEnabled) {
+            assertThrows(EVCacheException.class, () -> {
+                evCache.appendOrAdd(key2, value3, null, 1000, EVCacheLatch.Policy.ALL);
+            });
+        } else {
+            latch = evCache.appendOrAdd(key2, value3, null, 1000, EVCacheLatch.Policy.ALL);
+            latch.await(3000, TimeUnit.MILLISECONDS);
+            assertEquals(evCache.get(key2), value2 + value3);
+        }
+
+        // appendoradd - add case
+        String key3 = Long.toString(System.currentTimeMillis());
+        String value4 = UUID.randomUUID().toString();
+        if (isHashingEnabled) {
+            assertThrows(EVCacheException.class, () -> {
+                evCache.appendOrAdd(key3, value4, null, 1000, EVCacheLatch.Policy.ALL);
+            });
+        } else {
+            latch = evCache.appendOrAdd(key3, value4, null, 1000, EVCacheLatch.Policy.ALL);
+            latch.await(3000, TimeUnit.MILLISECONDS);
+            // get
+            assertEquals(evCache.get(key3), value4);
+        }
+
+        // append
+        String value5 = UUID.randomUUID().toString();
+        if (isHashingEnabled) {
+            assertThrows(EVCacheException.class, () -> {
+                evCache.append(key3, value5, 1000);
+            });
+        } else {
+            Future<Boolean> futures[] = evCache.append(key3, value5, 1000);
+            for (Future future : futures) {
+                assertTrue((Boolean) future.get());
+            }
+            // get
+            assertEquals(evCache.get(key3), value4 + value5);
+        }
+
+        String key4 = Long.toString(System.currentTimeMillis());
+        assertEquals(evCache.incr(key4, 1, 10, 1000), 10);
+        assertEquals(evCache.incr(key4, 10, 10, 1000), 20);
+
+        // decr
+        String key5 = Long.toString(System.currentTimeMillis());
+        assertEquals(evCache.decr(key5, 1, 10, 1000), 10);
+        assertEquals(evCache.decr(key5, 20, 10, 1000), 0);
+
+        // delete
+        latch = evCache.delete(key1, EVCacheLatch.Policy.ALL);
+        latch.await(1000, TimeUnit.MILLISECONDS);
+        latch = evCache.delete(key2, EVCacheLatch.Policy.ALL);
+        latch.await(1000, TimeUnit.MILLISECONDS);
+        latch = evCache.delete(key3, EVCacheLatch.Policy.ALL);
+        latch.await(1000, TimeUnit.MILLISECONDS);
+        latch = evCache.delete(key4, EVCacheLatch.Policy.ALL);
+        latch.await(1000, TimeUnit.MILLISECONDS);
+        latch = evCache.delete(key5, EVCacheLatch.Policy.ALL);
+        latch.await(1000, TimeUnit.MILLISECONDS);
+
+        assertNull(evCache.get(key1));
+        assertNull(evCache.get(key2));
+        assertNull(evCache.get(key3));
+        assertNull(evCache.get(key4));
+        assertNull(evCache.get(key5));
     }
 
     public void testAll() {

--- a/evcache-core/src/main/java/com/netflix/evcache/EVCacheImpl.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/EVCacheImpl.java
@@ -27,7 +27,6 @@ import org.slf4j.LoggerFactory;
 
 import com.netflix.archaius.api.Property;
 import com.netflix.archaius.api.PropertyRepository;
-import com.netflix.evcache.EVCache.Call;
 import com.netflix.evcache.EVCacheInMemoryCache.DataNotFoundException;
 import com.netflix.evcache.EVCacheLatch.Policy;
 import com.netflix.evcache.event.EVCacheEvent;
@@ -90,6 +89,8 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
     private final Property<Boolean> ignoreTouch;
     private final Property<Boolean> hashKey;
     private final Property<String> hashingAlgo;
+    private final Property<Boolean> shouldEncodeHashKey;
+    private final Property<Integer> maxHashingBytes;
     private final EVCacheTranscoder evcacheValueTranscoder;
     private final Property<Integer> maxReadDuration, maxWriteDuration;
 
@@ -147,6 +148,8 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
 
         this.hashKey = propertyRepository.get(appName + ".hash.key", Boolean.class).orElse(false);
         this.hashingAlgo = propertyRepository.get(appName + ".hash.algo", String.class).orElse("siphash24");
+        this.shouldEncodeHashKey = propertyRepository.get(appName + ".hash.encode", Boolean.class).orElse(true);
+        this.maxHashingBytes = propertyRepository.get(appName + ".hash.max.bytes", Integer.class).orElse(-1);
         this.autoHashKeys = propertyRepository.get(_appName + ".auto.hash.keys", Boolean.class).orElseGet("evcache.auto.hash.keys").orElse(false);
         this.evcacheValueTranscoder = new EVCacheTranscoder();
         evcacheValueTranscoder.setCompressionThreshold(Integer.MAX_VALUE);
@@ -204,7 +207,7 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
         }
 
         boolean shouldHashKeyAtAppLevel = hashKey.get() || (canonicalKey.length() > this.maxKeyLength.get() && autoHashKeys.get());
-        final EVCacheKey evcKey = new EVCacheKey(_appName, key, canonicalKey, shouldHashKeyAtAppLevel ? KeyHasher.getHashingAlgorithmFromString(hashingAlgo.get()) : null);
+        final EVCacheKey evcKey = new EVCacheKey(_appName, key, canonicalKey, shouldHashKeyAtAppLevel ? KeyHasher.getHashingAlgorithmFromString(hashingAlgo.get()) : null, this.shouldEncodeHashKey, this.maxHashingBytes);
         if (log.isDebugEnabled() && shouldLog()) log.debug("Key : " + key + "; EVCacheKey : " + evcKey);
         return evcKey;
     }
@@ -904,7 +907,7 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
         if (client == null) return null;
         final Transcoder<T> transcoder = (tc == null) ? ((_transcoder == null) ? (Transcoder<T>) client.getTranscoder() : (Transcoder<T>) _transcoder) : tc;
         try {
-            String hashKey = evcKey.getHashKey(client.isDuetClient(), client.getHashingAlgorithm());
+            String hashKey = evcKey.getHashKey(client.isDuetClient(), client.getHashingAlgorithm(), client.shouldEncodeHashKey(), client.getMaxHashingBytes());
             String canonicalKey = evcKey.getCanonicalKey(client.isDuetClient());
 
             if(hashKey != null) {
@@ -945,7 +948,7 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
     private EVCacheItemMetaData getEVCacheItemMetaData(EVCacheClient client, EVCacheKey evcKey, boolean throwException, boolean hasZF) throws Exception {
         if (client == null) return null;
         try {
-            return client.metaDebug(evcKey.getDerivedKey(client.isDuetClient(), client.getHashingAlgorithm()));
+            return client.metaDebug(evcKey.getDerivedKey(client.isDuetClient(), client.getHashingAlgorithm(), client.shouldEncodeHashKey(), client.getMaxHashingBytes()));
         } catch (EVCacheConnectException ex) {
             if (log.isDebugEnabled() && shouldLog()) log.debug("EVCacheConnectException while getting with metadata for APP " + _appName + ", key : " + evcKey + "; hasZF : " + hasZF, ex);
             if (!throwException || hasZF) return null;
@@ -969,7 +972,7 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
         if (client == null) return null;
         final Transcoder<T> transcoder = (tc == null) ? ((_transcoder == null) ? (Transcoder<T>) client.getTranscoder() : (Transcoder<T>) _transcoder) : tc;
         try {
-            String hashKey = evcKey.getHashKey(client.isDuetClient(), client.getHashingAlgorithm());
+            String hashKey = evcKey.getHashKey(client.isDuetClient(), client.getHashingAlgorithm(), client.shouldEncodeHashKey(), client.getMaxHashingBytes());
             String canonicalKey = evcKey.getCanonicalKey(client.isDuetClient());
             if (hashKey != null) {
                 final EVCacheItem<Object> obj = client.metaGet(hashKey, evcacheValueTranscoder, throwException, hasZF);
@@ -979,7 +982,7 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
                         return null;
                     }
                     if (!(val.getKey().equals(canonicalKey))) {
-                        incrementFailure(EVCacheMetricsFactory.KEY_HASH_COLLISION, Call.GET.name(), EVCacheMetricsFactory.META_GET_OPERATION);
+                        incrementFailure(EVCacheMetricsFactory.KEY_HASH_COLLISION, Call.META_GET.name(), EVCacheMetricsFactory.META_GET_OPERATION);
                         return null;
                     }
                     final CachedData cd = new CachedData(val.getFlags(), val.getValue(), CachedData.MAX_SIZE);
@@ -1019,7 +1022,7 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
 
     private <T> Single<T> getData(EVCacheClient client, EVCacheKey evcKey, Transcoder<T> tc, boolean throwException, boolean hasZF, Scheduler scheduler) {
         if (client == null) return Single.error(new IllegalArgumentException("Client cannot be null"));
-        if(evcKey.getHashKey(client.isDuetClient(), client.getHashingAlgorithm()) != null) {
+        if(evcKey.getHashKey(client.isDuetClient(), client.getHashingAlgorithm(), client.shouldEncodeHashKey(), client.getMaxHashingBytes()) != null) {
             return Single.error(new IllegalArgumentException("Not supported"));
         } else {
             final Transcoder<T> transcoder = (tc == null) ? ((_transcoder == null) ? (Transcoder<T>) client.getTranscoder() : (Transcoder<T>) _transcoder) : tc;
@@ -1393,7 +1396,7 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
     private void touchData(EVCacheKey evcKey, int timeToLive, EVCacheClient[] clients, EVCacheLatch latch ) throws Exception {
         checkTTL(timeToLive, Call.TOUCH);
         for (EVCacheClient client : clients) {
-            client.touch(evcKey.getDerivedKey(client.isDuetClient(), client.getHashingAlgorithm()), timeToLive, latch);
+            client.touch(evcKey.getDerivedKey(client.isDuetClient(), client.getHashingAlgorithm(), client.shouldEncodeHashKey(), client.getMaxHashingBytes()), timeToLive, latch);
         }
     }
 
@@ -1438,7 +1441,7 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
         final Future<T> r;
         final long start = EVCacheMetricsFactory.getInstance().getRegistry().clock().wallTime();
         try {
-            String hashKey = evcKey.getHashKey(client.isDuetClient(), client.getHashingAlgorithm());
+            String hashKey = evcKey.getHashKey(client.isDuetClient(), client.getHashingAlgorithm(), client.shouldEncodeHashKey(), client.getMaxHashingBytes());
             String canonicalKey = evcKey.getCanonicalKey(client.isDuetClient());
             if(hashKey != null) {
                 final Future<Object> objFuture = client.asyncGet(hashKey, evcacheValueTranscoder, throwExc, false);
@@ -1514,7 +1517,7 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
             final Map<String, EVCacheKey> keyMap = new HashMap<String, EVCacheKey>(evcacheKeys.size() * 2);
             for(EVCacheKey evcKey : evcacheKeys) {
                 String key = evcKey.getCanonicalKey(client.isDuetClient());
-                String hashKey = evcKey.getHashKey(client.isDuetClient(), client.getHashingAlgorithm());
+                String hashKey = evcKey.getHashKey(client.isDuetClient(), client.getHashingAlgorithm(), client.shouldEncodeHashKey(), client.getMaxHashingBytes());
                 if(hashKey != null) {
                     if (log.isDebugEnabled() && shouldLog()) log.debug("APP " + _appName + ", key [" + key + "], has been hashed [" + hashKey + "]");
                     key = hashKey;
@@ -1900,7 +1903,7 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
             CachedData cd = null;
             for (EVCacheClient client : clients) {
                 String canonicalKey = evcKey.getCanonicalKey(client.isDuetClient());
-                String hashKey = evcKey.getHashKey(client.isDuetClient(), client.getHashingAlgorithm());
+                String hashKey = evcKey.getHashKey(client.isDuetClient(), client.getHashingAlgorithm(), client.shouldEncodeHashKey(), client.getMaxHashingBytes());
                 if (cd == null) {
                     if (tc != null) {
                         cd = tc.encode(value);
@@ -1993,7 +1996,7 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
                     }
                     //if (cd != null) EVCacheMetricsFactory.getInstance().getDistributionSummary(_appName + "-AppendData-Size", tags).record(cd.getData().length);
                 }
-                final Future<Boolean> future = client.append(evcKey.getDerivedKey(client.isDuetClient(), client.getHashingAlgorithm()), cd);
+                final Future<Boolean> future = client.append(evcKey.getDerivedKey(client.isDuetClient(), client.getHashingAlgorithm(), client.shouldEncodeHashKey(), client.getMaxHashingBytes()), cd);
                 futures[index++] = new EVCacheFuture(future, key, _appName, client.getServerGroup());
             }
             if (event != null) {
@@ -2089,7 +2092,7 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
         final EVCacheLatchImpl latch = new EVCacheLatchImpl(policy == null ? Policy.ALL_MINUS_1 : policy, clients.length - _pool.getWriteOnlyEVCacheClients().length, _appName);
         try {
             for (int i = 0; i < clients.length; i++) {
-                Future<Boolean> future = clients[i].delete(evcKey.getDerivedKey(clients[i].isDuetClient(), clients[i].getHashingAlgorithm()), latch);
+                Future<Boolean> future = clients[i].delete(evcKey.getDerivedKey(clients[i].isDuetClient(), clients[i].getHashingAlgorithm(), clients[i].shouldEncodeHashKey(), clients[i].getMaxHashingBytes()), latch);
                 if (log.isDebugEnabled() && shouldLog()) log.debug("DELETE : APP " + _appName + ", Future " + future + " for key : " + evcKey);
             }
 
@@ -2164,7 +2167,7 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
             final long[] vals = new long[clients.length];
             int index = 0;
             for (EVCacheClient client : clients) {
-                vals[index] = client.incr(evcKey.getDerivedKey(client.isDuetClient(), client.getHashingAlgorithm()), by, defaultVal, timeToLive);
+                vals[index] = client.incr(evcKey.getDerivedKey(client.isDuetClient(), client.getHashingAlgorithm(), client.shouldEncodeHashKey(), client.getMaxHashingBytes()), by, defaultVal, timeToLive);
                 if (vals[index] != -1 && currentValue < vals[index]) {
                     currentValue = vals[index];
                     if (log.isDebugEnabled()) log.debug("INCR : APP " + _appName + " current value = " + currentValue + " for key : " + key + " from client : " + client);
@@ -2179,12 +2182,12 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
                     if (vals[i] == -1 && currentValue > -1) {
                         if (log.isDebugEnabled()) log.debug("INCR : APP " + _appName + "; Zone " + clients[i].getZone()
                                 + " had a value = -1 so setting it to current value = " + currentValue + " for key : " + key);
-                        clients[i].incr(evcKey.getDerivedKey(clients[i].isDuetClient(), clients[i].getHashingAlgorithm()), 0, currentValue, timeToLive);
+                        clients[i].incr(evcKey.getDerivedKey(clients[i].isDuetClient(), clients[i].getHashingAlgorithm(), clients[i].shouldEncodeHashKey(), clients[i].getMaxHashingBytes()), 0, currentValue, timeToLive);
                     } else if (vals[i] != currentValue) {
                         if(cd == null) cd = clients[i].getTranscoder().encode(String.valueOf(currentValue));
                         if (log.isDebugEnabled()) log.debug("INCR : APP " + _appName + "; Zone " + clients[i].getZone()
                                 + " had a value of " + vals[i] + " so setting it to current value = " + currentValue + " for key : " + key);
-                        clients[i].set(evcKey.getDerivedKey(clients[i].isDuetClient(), clients[i].getHashingAlgorithm()), cd, timeToLive);
+                        clients[i].set(evcKey.getDerivedKey(clients[i].isDuetClient(), clients[i].getHashingAlgorithm(), clients[i].shouldEncodeHashKey(), clients[i].getMaxHashingBytes()), cd, timeToLive);
                     }
                 }
             }
@@ -2246,7 +2249,7 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
             final long[] vals = new long[clients.length];
             int index = 0;
             for (EVCacheClient client : clients) {
-                vals[index] = client.decr(evcKey.getDerivedKey(client.isDuetClient(), client.getHashingAlgorithm()), by, defaultVal, timeToLive);
+                vals[index] = client.decr(evcKey.getDerivedKey(client.isDuetClient(), client.getHashingAlgorithm(), client.shouldEncodeHashKey(), client.getMaxHashingBytes()), by, defaultVal, timeToLive);
                 if (vals[index] != -1 && currentValue < vals[index]) {
                     currentValue = vals[index];
                     if (log.isDebugEnabled()) log.debug("DECR : APP " + _appName + " current value = " + currentValue + " for key : " + key + " from client : " + client);
@@ -2263,13 +2266,13 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
                         if (log.isDebugEnabled()) log.debug("DECR : APP " + _appName + "; Zone " + clients[i].getZone()
                                 + " had a value = -1 so setting it to current value = "
                                 + currentValue + " for key : " + key);
-                        clients[i].decr(evcKey.getDerivedKey(clients[i].isDuetClient(), clients[i].getHashingAlgorithm()), 0, currentValue, timeToLive);
+                        clients[i].decr(evcKey.getDerivedKey(clients[i].isDuetClient(), clients[i].getHashingAlgorithm(), clients[i].shouldEncodeHashKey(), clients[i].getMaxHashingBytes()), 0, currentValue, timeToLive);
                     } else if (vals[i] != currentValue) {
                         if(cd == null) cd = clients[i].getTranscoder().encode(currentValue);
                         if (log.isDebugEnabled()) log.debug("DECR : APP " + _appName + "; Zone " + clients[i].getZone()
                                 + " had a value of " + vals[i]
                                         + " so setting it to current value = " + currentValue + " for key : " + key);
-                        clients[i].set(evcKey.getDerivedKey(clients[i].isDuetClient(), clients[i].getHashingAlgorithm()), cd, timeToLive);
+                        clients[i].set(evcKey.getDerivedKey(clients[i].isDuetClient(), clients[i].getHashingAlgorithm(), clients[i].shouldEncodeHashKey(), clients[i].getMaxHashingBytes()), cd, timeToLive);
                     }
                 }
             }
@@ -2356,12 +2359,12 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
                         cd = client.getTranscoder().encode(value);
                     }
 
-                    if(evcKey.getHashKey(client.isDuetClient(), client.getHashingAlgorithm()) != null) {
+                    if(evcKey.getHashKey(client.isDuetClient(), client.getHashingAlgorithm(), client.shouldEncodeHashKey(), client.getMaxHashingBytes()) != null) {
                         final EVCacheValue val = new EVCacheValue(evcKey.getCanonicalKey(client.isDuetClient()), cd.getData(), cd.getFlags(), timeToLive, System.currentTimeMillis());
                         cd = evcacheValueTranscoder.encode(val);
                     }
                 }
-                final Future<Boolean> future = client.replace(evcKey.getDerivedKey(client.isDuetClient(), client.getHashingAlgorithm()), cd, timeToLive, latch);
+                final Future<Boolean> future = client.replace(evcKey.getDerivedKey(client.isDuetClient(), client.getHashingAlgorithm(), client.shouldEncodeHashKey(), client.getMaxHashingBytes()), cd, timeToLive, latch);
                 futures[index++] = new EVCacheFuture(future, key, _appName, client.getServerGroup());
             }
             if (event != null) {
@@ -2448,7 +2451,7 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
                         cd = client.getTranscoder().encode(value);
                     }
                 }
-                final Future<Boolean> future = client.appendOrAdd(evcKey.getDerivedKey(client.isDuetClient(), client.getHashingAlgorithm()), cd, timeToLive, latch);
+                final Future<Boolean> future = client.appendOrAdd(evcKey.getDerivedKey(client.isDuetClient(), client.getHashingAlgorithm(), client.shouldEncodeHashKey(), client.getMaxHashingBytes()), cd, timeToLive, latch);
                 if (log.isDebugEnabled() && shouldLog()) log.debug("APPEND_OR_ADD : APP " + _appName + ", Future " + future + " for key : " + evcKey);
             }
             if (event != null) {

--- a/evcache-core/src/main/java/com/netflix/evcache/EVCacheImpl.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/EVCacheImpl.java
@@ -1986,6 +1986,11 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
             CachedData cd = null;
             int index = 0;
             for (EVCacheClient client : clients) {
+                // ensure key hashing is not enabled
+                if (evcKey.getHashKey(client.isDuetClient(), client.getHashingAlgorithm(), client.shouldEncodeHashKey(), client.getMaxHashingBytes()) != null) {
+                    throw new IllegalArgumentException("append is not supported when key hashing is enabled.");
+                }
+
                 if (cd == null) {
                     if (tc != null) {
                         cd = tc.encode(value);
@@ -2442,6 +2447,11 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
         try {
             CachedData cd = null;
             for (EVCacheClient client : clients) {
+                // ensure key hashing is not enabled
+                if (evcKey.getHashKey(client.isDuetClient(), client.getHashingAlgorithm(), client.shouldEncodeHashKey(), client.getMaxHashingBytes()) != null) {
+                    throw new IllegalArgumentException("appendOrAdd is not supported when key hashing is enabled.");
+                }
+
                 if (cd == null) {
                     if (tc != null) {
                         cd = tc.encode(value);

--- a/evcache-core/src/main/java/com/netflix/evcache/EVCacheImpl.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/EVCacheImpl.java
@@ -199,20 +199,12 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
             canonicalKey  = new StringBuilder(keyLength).append(_cacheName).append(':').append(key).toString();
         }
 
-        final String hashedKey;
-        if(hashKey.get()) {
-            hashedKey = KeyHasher.getHashedKey(canonicalKey, hashingAlgo.get());
-        } else if(autoHashKeys.get() && canonicalKey.length() > this.maxKeyLength.get()) {
-            hashedKey = KeyHasher.getHashedKey(canonicalKey, hashingAlgo.get());
-        } else {
-            hashedKey = null;
-        }
-
-        if (hashedKey == null && canonicalKey.length() > this.maxKeyLength.get()) {
+        if (canonicalKey.length() > this.maxKeyLength.get() && !hashKey.get() && !autoHashKeys.get()) {
             throw new IllegalArgumentException("Key is too long (maxlen = " + this.maxKeyLength.get() + ')');
         }
 
-        final EVCacheKey evcKey = new EVCacheKey(_appName, key, canonicalKey, hashedKey, hashingAlgo);
+        boolean shouldHashKeyAtAppLevel = hashKey.get() || (canonicalKey.length() > this.maxKeyLength.get() && autoHashKeys.get());
+        final EVCacheKey evcKey = new EVCacheKey(_appName, key, canonicalKey, shouldHashKeyAtAppLevel ? KeyHasher.getHashingAlgorithmFromString(hashingAlgo.get()) : null);
         if (log.isDebugEnabled() && shouldLog()) log.debug("Key : " + key + "; EVCacheKey : " + evcKey);
         return evcKey;
     }
@@ -912,7 +904,7 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
         if (client == null) return null;
         final Transcoder<T> transcoder = (tc == null) ? ((_transcoder == null) ? (Transcoder<T>) client.getTranscoder() : (Transcoder<T>) _transcoder) : tc;
         try {
-            String hashKey = evcKey.getHashKey(client.isDuetClient());
+            String hashKey = evcKey.getHashKey(client.isDuetClient(), client.getHashingAlgorithm());
             String canonicalKey = evcKey.getCanonicalKey(client.isDuetClient());
 
             if(hashKey != null) {
@@ -953,7 +945,7 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
     private EVCacheItemMetaData getEVCacheItemMetaData(EVCacheClient client, EVCacheKey evcKey, boolean throwException, boolean hasZF) throws Exception {
         if (client == null) return null;
         try {
-            return client.metaDebug(evcKey.getDerivedKey(client.isDuetClient()));
+            return client.metaDebug(evcKey.getDerivedKey(client.isDuetClient(), client.getHashingAlgorithm()));
         } catch (EVCacheConnectException ex) {
             if (log.isDebugEnabled() && shouldLog()) log.debug("EVCacheConnectException while getting with metadata for APP " + _appName + ", key : " + evcKey + "; hasZF : " + hasZF, ex);
             if (!throwException || hasZF) return null;
@@ -977,7 +969,30 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
         if (client == null) return null;
         final Transcoder<T> transcoder = (tc == null) ? ((_transcoder == null) ? (Transcoder<T>) client.getTranscoder() : (Transcoder<T>) _transcoder) : tc;
         try {
-            return client.metaGet(evcKey.getDerivedKey(client.isDuetClient()), transcoder, throwException, hasZF);
+            String hashKey = evcKey.getHashKey(client.isDuetClient(), client.getHashingAlgorithm());
+            String canonicalKey = evcKey.getCanonicalKey(client.isDuetClient());
+            if (hashKey != null) {
+                final EVCacheItem<Object> obj = client.metaGet(hashKey, evcacheValueTranscoder, throwException, hasZF);
+                if (obj.getData() instanceof EVCacheValue) {
+                    final EVCacheValue val = (EVCacheValue) obj.getData();
+                    if (null == val) {
+                        return null;
+                    }
+                    if (!(val.getKey().equals(canonicalKey))) {
+                        incrementFailure(EVCacheMetricsFactory.KEY_HASH_COLLISION, Call.GET.name(), EVCacheMetricsFactory.META_GET_OPERATION);
+                        return null;
+                    }
+                    final CachedData cd = new CachedData(val.getFlags(), val.getValue(), CachedData.MAX_SIZE);
+                    T t = transcoder.decode(cd);
+                    obj.setData(t);
+                    obj.setFlag(val.getFlags());
+                    return (EVCacheItem<T>) obj;
+                } else {
+                    return null;
+                }
+            } else {
+                return client.metaGet(canonicalKey, transcoder, throwException, hasZF);
+            }
         } catch (EVCacheConnectException ex) {
             if (log.isDebugEnabled() && shouldLog()) log.debug("EVCacheConnectException while getting with meta data for APP " + _appName + ", key : " + evcKey + "; hasZF : " + hasZF, ex);
             if (!throwException || hasZF) return null;
@@ -1004,7 +1019,7 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
 
     private <T> Single<T> getData(EVCacheClient client, EVCacheKey evcKey, Transcoder<T> tc, boolean throwException, boolean hasZF, Scheduler scheduler) {
         if (client == null) return Single.error(new IllegalArgumentException("Client cannot be null"));
-        if(hashKey.get()) {
+        if(evcKey.getHashKey(client.isDuetClient(), client.getHashingAlgorithm()) != null) {
             return Single.error(new IllegalArgumentException("Not supported"));
         } else {
             final Transcoder<T> transcoder = (tc == null) ? ((_transcoder == null) ? (Transcoder<T>) client.getTranscoder() : (Transcoder<T>) _transcoder) : tc;
@@ -1042,7 +1057,6 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
     public <T> T getAndTouch(String key, int timeToLive) throws EVCacheException {
         return this.getAndTouch(key, timeToLive, (Transcoder<T>) _transcoder);
     }
-
 
     public <T> Single<T> getAndTouch(String key, int timeToLive, Scheduler scheduler) {
         return this.getAndTouch(key, timeToLive, (Transcoder<T>) _transcoder, scheduler);
@@ -1376,11 +1390,10 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
         touchData(evcKey, timeToLive, clients, null);
     }
 
-
     private void touchData(EVCacheKey evcKey, int timeToLive, EVCacheClient[] clients, EVCacheLatch latch ) throws Exception {
         checkTTL(timeToLive, Call.TOUCH);
         for (EVCacheClient client : clients) {
-            client.touch(evcKey.getDerivedKey(client.isDuetClient()), timeToLive, latch);
+            client.touch(evcKey.getDerivedKey(client.isDuetClient(), client.getHashingAlgorithm()), timeToLive, latch);
         }
     }
 
@@ -1425,7 +1438,7 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
         final Future<T> r;
         final long start = EVCacheMetricsFactory.getInstance().getRegistry().clock().wallTime();
         try {
-            String hashKey = evcKey.getHashKey(client.isDuetClient());
+            String hashKey = evcKey.getHashKey(client.isDuetClient(), client.getHashingAlgorithm());
             String canonicalKey = evcKey.getCanonicalKey(client.isDuetClient());
             if(hashKey != null) {
                 final Future<Object> objFuture = client.asyncGet(hashKey, evcacheValueTranscoder, throwExc, false);
@@ -1501,7 +1514,7 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
             final Map<String, EVCacheKey> keyMap = new HashMap<String, EVCacheKey>(evcacheKeys.size() * 2);
             for(EVCacheKey evcKey : evcacheKeys) {
                 String key = evcKey.getCanonicalKey(client.isDuetClient());
-                String hashKey = evcKey.getHashKey(client.isDuetClient());
+                String hashKey = evcKey.getHashKey(client.isDuetClient(), client.getHashingAlgorithm());
                 if(hashKey != null) {
                     if (log.isDebugEnabled() && shouldLog()) log.debug("APP " + _appName + ", key [" + key + "], has been hashed [" + hashKey + "]");
                     key = hashKey;
@@ -1887,7 +1900,7 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
             CachedData cd = null;
             for (EVCacheClient client : clients) {
                 String canonicalKey = evcKey.getCanonicalKey(client.isDuetClient());
-                String hashKey = evcKey.getHashKey(client.isDuetClient());
+                String hashKey = evcKey.getHashKey(client.isDuetClient(), client.getHashingAlgorithm());
                 if (cd == null) {
                     if (tc != null) {
                         cd = tc.encode(value);
@@ -1980,7 +1993,7 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
                     }
                     //if (cd != null) EVCacheMetricsFactory.getInstance().getDistributionSummary(_appName + "-AppendData-Size", tags).record(cd.getData().length);
                 }
-                final Future<Boolean> future = client.append(evcKey.getDerivedKey(client.isDuetClient()), cd);
+                final Future<Boolean> future = client.append(evcKey.getDerivedKey(client.isDuetClient(), client.getHashingAlgorithm()), cd);
                 futures[index++] = new EVCacheFuture(future, key, _appName, client.getServerGroup());
             }
             if (event != null) {
@@ -2076,7 +2089,7 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
         final EVCacheLatchImpl latch = new EVCacheLatchImpl(policy == null ? Policy.ALL_MINUS_1 : policy, clients.length - _pool.getWriteOnlyEVCacheClients().length, _appName);
         try {
             for (int i = 0; i < clients.length; i++) {
-                Future<Boolean> future = clients[i].delete(evcKey.getDerivedKey(clients[i].isDuetClient()), latch);
+                Future<Boolean> future = clients[i].delete(evcKey.getDerivedKey(clients[i].isDuetClient(), clients[i].getHashingAlgorithm()), latch);
                 if (log.isDebugEnabled() && shouldLog()) log.debug("DELETE : APP " + _appName + ", Future " + future + " for key : " + evcKey);
             }
 
@@ -2151,7 +2164,7 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
             final long[] vals = new long[clients.length];
             int index = 0;
             for (EVCacheClient client : clients) {
-                vals[index] = client.incr(evcKey.getDerivedKey(client.isDuetClient()), by, defaultVal, timeToLive);
+                vals[index] = client.incr(evcKey.getDerivedKey(client.isDuetClient(), client.getHashingAlgorithm()), by, defaultVal, timeToLive);
                 if (vals[index] != -1 && currentValue < vals[index]) {
                     currentValue = vals[index];
                     if (log.isDebugEnabled()) log.debug("INCR : APP " + _appName + " current value = " + currentValue + " for key : " + key + " from client : " + client);
@@ -2166,12 +2179,12 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
                     if (vals[i] == -1 && currentValue > -1) {
                         if (log.isDebugEnabled()) log.debug("INCR : APP " + _appName + "; Zone " + clients[i].getZone()
                                 + " had a value = -1 so setting it to current value = " + currentValue + " for key : " + key);
-                        clients[i].incr(evcKey.getDerivedKey(clients[i].isDuetClient()), 0, currentValue, timeToLive);
+                        clients[i].incr(evcKey.getDerivedKey(clients[i].isDuetClient(), clients[i].getHashingAlgorithm()), 0, currentValue, timeToLive);
                     } else if (vals[i] != currentValue) {
                         if(cd == null) cd = clients[i].getTranscoder().encode(String.valueOf(currentValue));
                         if (log.isDebugEnabled()) log.debug("INCR : APP " + _appName + "; Zone " + clients[i].getZone()
                                 + " had a value of " + vals[i] + " so setting it to current value = " + currentValue + " for key : " + key);
-                        clients[i].set(evcKey.getDerivedKey(clients[i].isDuetClient()), cd, timeToLive);
+                        clients[i].set(evcKey.getDerivedKey(clients[i].isDuetClient(), clients[i].getHashingAlgorithm()), cd, timeToLive);
                     }
                 }
             }
@@ -2233,7 +2246,7 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
             final long[] vals = new long[clients.length];
             int index = 0;
             for (EVCacheClient client : clients) {
-                vals[index] = client.decr(evcKey.getDerivedKey(client.isDuetClient()), by, defaultVal, timeToLive);
+                vals[index] = client.decr(evcKey.getDerivedKey(client.isDuetClient(), client.getHashingAlgorithm()), by, defaultVal, timeToLive);
                 if (vals[index] != -1 && currentValue < vals[index]) {
                     currentValue = vals[index];
                     if (log.isDebugEnabled()) log.debug("DECR : APP " + _appName + " current value = " + currentValue + " for key : " + key + " from client : " + client);
@@ -2250,13 +2263,13 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
                         if (log.isDebugEnabled()) log.debug("DECR : APP " + _appName + "; Zone " + clients[i].getZone()
                                 + " had a value = -1 so setting it to current value = "
                                 + currentValue + " for key : " + key);
-                        clients[i].decr(evcKey.getDerivedKey(clients[i].isDuetClient()), 0, currentValue, timeToLive);
+                        clients[i].decr(evcKey.getDerivedKey(clients[i].isDuetClient(), clients[i].getHashingAlgorithm()), 0, currentValue, timeToLive);
                     } else if (vals[i] != currentValue) {
                         if(cd == null) cd = clients[i].getTranscoder().encode(currentValue);
                         if (log.isDebugEnabled()) log.debug("DECR : APP " + _appName + "; Zone " + clients[i].getZone()
                                 + " had a value of " + vals[i]
                                         + " so setting it to current value = " + currentValue + " for key : " + key);
-                        clients[i].set(evcKey.getDerivedKey(clients[i].isDuetClient()), cd, timeToLive);
+                        clients[i].set(evcKey.getDerivedKey(clients[i].isDuetClient(), clients[i].getHashingAlgorithm()), cd, timeToLive);
                     }
                 }
             }
@@ -2343,12 +2356,12 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
                         cd = client.getTranscoder().encode(value);
                     }
 
-                    if(hashKey.get()) {
+                    if(evcKey.getHashKey(client.isDuetClient(), client.getHashingAlgorithm()) != null) {
                         final EVCacheValue val = new EVCacheValue(evcKey.getCanonicalKey(client.isDuetClient()), cd.getData(), cd.getFlags(), timeToLive, System.currentTimeMillis());
                         cd = evcacheValueTranscoder.encode(val);
                     }
                 }
-                final Future<Boolean> future = client.replace(evcKey.getDerivedKey(client.isDuetClient()), cd, timeToLive, latch);
+                final Future<Boolean> future = client.replace(evcKey.getDerivedKey(client.isDuetClient(), client.getHashingAlgorithm()), cd, timeToLive, latch);
                 futures[index++] = new EVCacheFuture(future, key, _appName, client.getServerGroup());
             }
             if (event != null) {
@@ -2435,7 +2448,7 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
                         cd = client.getTranscoder().encode(value);
                     }
                 }
-                final Future<Boolean> future = client.appendOrAdd(evcKey.getDerivedKey(client.isDuetClient()), cd, timeToLive, latch);
+                final Future<Boolean> future = client.appendOrAdd(evcKey.getDerivedKey(client.isDuetClient(), client.getHashingAlgorithm()), cd, timeToLive, latch);
                 if (log.isDebugEnabled() && shouldLog()) log.debug("APPEND_OR_ADD : APP " + _appName + ", Future " + future + " for key : " + evcKey);
             }
             if (event != null) {
@@ -2470,7 +2483,6 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
         if(latch != null) return latch.getAllFutures().toArray(new Future[latch.getAllFutures().size()]);
         return new EVCacheFuture[0];
     }
-
 
     public <T> boolean add(String key, T value, Transcoder<T> tc, int timeToLive) throws EVCacheException {
         final EVCacheLatch latch = add(key, value, tc, timeToLive, Policy.NONE);
@@ -2540,7 +2552,7 @@ final public class EVCacheImpl implements EVCache, EVCacheImplMBean {
                 }
             }
             if(clientUtil == null) clientUtil = new EVCacheClientUtil(_pool);
-            latch = clientUtil.add(evcKey, cd, hashKey.get(), evcacheValueTranscoder, timeToLive, policy);
+            latch = clientUtil.add(evcKey, cd, evcacheValueTranscoder, timeToLive, policy);
             if (event != null) {
                 event.setTTL(timeToLive);
                 event.setCachedData(cd);

--- a/evcache-core/src/main/java/com/netflix/evcache/event/EVCacheEvent.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/event/EVCacheEvent.java
@@ -170,7 +170,7 @@ public class EVCacheEvent {
     public Collection<MemcachedNode> getMemcachedNode(EVCacheKey evckey) {
         final Collection<MemcachedNode> nodeList = new ArrayList<MemcachedNode>(clients.size());
         for(EVCacheClient client : clients) {
-            String key = evckey.getDerivedKey(client.isDuetClient());
+            String key = evckey.getDerivedKey(client.isDuetClient(), client.getHashingAlgorithm());
             nodeList.add(client.getNodeLocator().getPrimary(key));
         }
         return nodeList;

--- a/evcache-core/src/main/java/com/netflix/evcache/event/EVCacheEvent.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/event/EVCacheEvent.java
@@ -170,7 +170,7 @@ public class EVCacheEvent {
     public Collection<MemcachedNode> getMemcachedNode(EVCacheKey evckey) {
         final Collection<MemcachedNode> nodeList = new ArrayList<MemcachedNode>(clients.size());
         for(EVCacheClient client : clients) {
-            String key = evckey.getDerivedKey(client.isDuetClient(), client.getHashingAlgorithm());
+            String key = evckey.getDerivedKey(client.isDuetClient(), client.getHashingAlgorithm(), client.shouldEncodeHashKey(), client.getMaxHashingBytes());
             nodeList.add(client.getNodeLocator().getPrimary(key));
         }
         return nodeList;

--- a/evcache-core/src/main/java/com/netflix/evcache/pool/EVCacheClient.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/pool/EVCacheClient.java
@@ -35,7 +35,6 @@ import com.netflix.evcache.EVCacheConnectException;
 import com.netflix.evcache.EVCacheException;
 import com.netflix.evcache.EVCacheLatch;
 import com.netflix.evcache.EVCacheReadQueueException;
-import com.netflix.evcache.EVCacheTranscoder;
 import com.netflix.evcache.metrics.EVCacheMetricsFactory;
 import com.netflix.evcache.operation.EVCacheFutures;
 import com.netflix.evcache.operation.EVCacheItem;
@@ -44,6 +43,7 @@ import com.netflix.evcache.operation.EVCacheLatchImpl;
 import com.netflix.evcache.pool.observer.EVCacheConnectionObserver;
 import com.netflix.evcache.util.EVCacheConfig;
 import com.netflix.evcache.util.KeyHasher;
+import com.netflix.evcache.util.KeyHasher.HashingAlgorithm;
 import com.netflix.spectator.api.BasicTag;
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.Tag;
@@ -88,11 +88,9 @@ public class EVCacheClient {
     private final Property<Integer> maxReadQueueSize;
     private final Property<Boolean> ignoreInactiveNodes;
     private final Property<Boolean> enableChunking;
-    private final Property<Boolean> hashKeyByApp;
     private final Property<Boolean> hashKeyByServerGroup;
     private final Property<Integer> chunkSize, writeBlock;
     private final ChunkTranscoder chunkingTranscoder;
-    private final EVCacheTranscoder evcacheValueTranscoder;
     private final SerializingTranscoder decodingTranscoder;
     private static final int SPECIAL_BYTEARRAY = (8 << 8);
     private final EVCacheClientPool pool;
@@ -148,10 +146,6 @@ public class EVCacheClient {
         this.decodingTranscoder = new SerializingTranscoder(Integer.MAX_VALUE);
         decodingTranscoder.setCompressionThreshold(Integer.MAX_VALUE);
 
-        this.evcacheValueTranscoder = new EVCacheTranscoder();
-        evcacheValueTranscoder.setCompressionThreshold(Integer.MAX_VALUE);
-
-        this.hashKeyByApp = EVCacheConfig.getInstance().getPropertyRepository().get(appName + ".hash.key", Boolean.class).orElseGet(appName + ".auto.hash.keys").orElseGet("evcache.auto.hash.keys").orElse(false);
         this.hashKeyByServerGroup = EVCacheConfig.getInstance().getPropertyRepository().get(this.serverGroup.getName() + ".hash.key", Boolean.class).orElse(false);
         this.hashingAlgo = EVCacheConfig.getInstance().getPropertyRepository().get(this.serverGroup.getName() + ".hash.algo", String.class).orElseGet(appName + ".hash.algo").orElse("siphash24");
         ping();
@@ -846,24 +840,6 @@ public class EVCacheClient {
     public <T> T get(String key, Transcoder<T> tc, boolean _throwException, boolean hasZF, boolean chunked) throws Exception {
         if (chunked) {
             return assembleChunks(key, false, 0, tc, hasZF);
-        } else if(shouldHashKey()) {
-            final String hKey = getHashedKey(key);
-            final Object obj = evcacheMemcachedClient.asyncGet(hKey, evcacheValueTranscoder, null).get(readTimeout.get(), TimeUnit.MILLISECONDS, _throwException, hasZF);
-            if(obj instanceof EVCacheValue) {
-                final EVCacheValue val = (EVCacheValue)obj;
-                if(val == null || !(val.getKey().equals(key))) {
-                    incrementFailure(EVCacheMetricsFactory.KEY_HASH_COLLISION, Call.GET);
-                    return null;
-                }
-                final CachedData cd = new CachedData(val.getFlags(), val.getValue(), CachedData.MAX_SIZE);
-                if(tc == null) {
-                    return (T)evcacheMemcachedClient.getTranscoder().decode(cd);
-                } else {
-                    return tc.decode(cd);
-                }
-            } else {
-                return null;
-            }
         } else {
             return evcacheMemcachedClient.asyncGet(key, tc, null).get(readTimeout.get(),
                     TimeUnit.MILLISECONDS, _throwException, hasZF);
@@ -885,24 +861,6 @@ public class EVCacheClient {
     public <T> Single<T> get(String key, Transcoder<T> tc, boolean _throwException, boolean hasZF, boolean chunked, Scheduler scheduler)  throws Exception {
         if (chunked) {
             return assembleChunks(key, _throwException, 0, tc, hasZF, scheduler);
-        }  else if(shouldHashKey()) {
-            final String hKey = getHashedKey(key);
-            final Object obj = evcacheMemcachedClient.asyncGet(hKey, evcacheValueTranscoder, null).get(readTimeout.get(), TimeUnit.MILLISECONDS, _throwException, hasZF);
-            if(obj instanceof EVCacheValue) {
-                final EVCacheValue val = (EVCacheValue)obj;
-                if(val == null || !(val.getKey().equals(key))) {
-                    incrementFailure(EVCacheMetricsFactory.KEY_HASH_COLLISION, Call.GET);
-                    return null;
-                }
-                final CachedData cd = new CachedData(val.getFlags(), val.getValue(), CachedData.MAX_SIZE);
-                if(tc == null) {
-                    return Single.just((T)evcacheMemcachedClient.getTranscoder().decode(cd));
-                } else {
-                    return Single.just(tc.decode(cd));
-                }
-            } else {
-                return null;
-            }
         } else {
             return evcacheMemcachedClient.asyncGet(key, tc, null)
                 .get(readTimeout.get(), TimeUnit.MILLISECONDS, _throwException, hasZF, scheduler);
@@ -940,30 +898,6 @@ public class EVCacheClient {
         final T returnVal;
         if (enableChunking.get()) {
             return assembleChunks(key, false, 0, tc, hasZF);
-        } else if(shouldHashKey()) {
-            final String hKey = getHashedKey(key);
-            final Object obj;
-            if(ignoreTouch.get()) {
-                obj = _client.asyncGet(hKey, evcacheValueTranscoder, null).get(readTimeout.get(), TimeUnit.MILLISECONDS, _throwException, hasZF);
-            } else {
-                final CASValue<Object> value = _client.asyncGetAndTouch(key, timeToLive, evcacheValueTranscoder).get(readTimeout.get(), TimeUnit.MILLISECONDS, _throwException, hasZF);
-                obj = (value == null) ? null : value.getValue();
-            }
-            if(obj != null && obj instanceof EVCacheValue) {
-                final EVCacheValue val = (EVCacheValue)obj;
-                if(val == null || !(val.getKey().equals(key))) {
-                    incrementFailure(EVCacheMetricsFactory.KEY_HASH_COLLISION, Call.GET_AND_TOUCH);
-                    return null;
-                }
-                final CachedData cd = new CachedData(val.getFlags(), val.getValue(), CachedData.MAX_SIZE);
-                if(tc == null) {
-                    return (T)_client.getTranscoder().decode(cd);
-                } else {
-                    return tc.decode(cd);
-                }
-            } else {
-                return null;
-            }
         } else {
             if(ignoreTouch.get()) {
                 returnVal = _client.asyncGet(key, tc, null).get(readTimeout.get(), TimeUnit.MILLISECONDS, _throwException, hasZF);
@@ -991,45 +925,6 @@ public class EVCacheClient {
             final Transcoder<T> tc = (transcoder == null) ? (Transcoder<T>) getTranscoder(): transcoder;
             if (enableChunking.get()) {
                 return assembleChunks(key, false, 0, tc, hasZF, scheduler);
-            } else if(shouldHashKey()) {
-                final String hKey = getHashedKey(key);
-                if(ignoreTouch.get()) {
-                    final Single<Object> value = _client.asyncGet(hKey, evcacheValueTranscoder, null).get(readTimeout.get(), TimeUnit.MILLISECONDS, _throwException, hasZF, scheduler);
-                    return value.flatMap(r -> {
-                        final CASValue<Object> rObj = (CASValue<Object>)r;
-                        final EVCacheValue val = (EVCacheValue)rObj.getValue();
-                        if(val == null || !(val.getKey().equals(key))) {
-                            incrementFailure(EVCacheMetricsFactory.KEY_HASH_COLLISION, Call.GET_AND_TOUCH);
-                            return null;
-                        }
-                        final CachedData cd = new CachedData(val.getFlags(), val.getValue(), CachedData.MAX_SIZE);
-                        if(tc == null) {
-                            return Single.just((T)_client.getTranscoder().decode(cd));
-                        } else {
-                            return Single.just(tc.decode(cd));
-                        }
-                    });
-                } else {
-                    final Single<CASValue<Object>> value = _client.asyncGetAndTouch(hKey, timeToLive, evcacheValueTranscoder).get(readTimeout.get(), TimeUnit.MILLISECONDS, _throwException, hasZF, scheduler);
-                    if(value != null ) {
-                        return value.flatMap(r -> {
-                            final CASValue<Object> rObj = (CASValue<Object>)r;
-                            final EVCacheValue val = (EVCacheValue)rObj.getValue();
-                            if(val == null || !(val.getKey().equals(key))) {
-                                incrementFailure(EVCacheMetricsFactory.KEY_HASH_COLLISION, Call.GET_AND_TOUCH);
-                                return null;
-                            }
-                            final CachedData cd = new CachedData(val.getFlags(), val.getValue(), CachedData.MAX_SIZE);
-                            if(tc == null) {
-                                return Single.just((T)_client.getTranscoder().decode(cd));
-                            } else {
-                                return Single.just(tc.decode(cd));
-                            }
-                        });
-                    } else {
-                        return null;
-                    }
-                }
             } else {
                 return _client.asyncGetAndTouch(key, timeToLive, tc)
                     .get(readTimeout.get(), TimeUnit.MILLISECONDS, _throwException, hasZF, scheduler)
@@ -1048,36 +943,6 @@ public class EVCacheClient {
             if (tc == null) tc = (Transcoder<T>) getTranscoder();
             if (enableChunking.get()) {
                 returnVal = assembleChunks(_canonicalKeys, tc, hasZF);
-            } else if(shouldHashKey()) {
-                final Collection<String> hashKeys = new ArrayList<String>(canonicalKeys.size());
-                returnVal = new HashMap<String, T>(canonicalKeys.size());
-                for(String cKey : canonicalKeys) {
-                    final String hKey = getHashedKey(cKey);
-                    hashKeys.add(hKey);
-                    returnVal.put(cKey, null);
-                }
-                final Map<String, Object> vals = evcacheMemcachedClient.asyncGetBulk(hashKeys, evcacheValueTranscoder, null).getSome(bulkReadTimeout.get(), TimeUnit.MILLISECONDS, _throwException, hasZF);
-                if(vals != null && !vals.isEmpty()) {
-                    for(Entry<String, Object> entry : vals.entrySet()) {
-                        final Object obj = entry.getValue();
-                        if(obj instanceof EVCacheValue) {
-                            final EVCacheValue val = (EVCacheValue)obj;
-                            if(val == null || !(returnVal.containsKey(val.getKey()))) {
-                                incrementFailure(EVCacheMetricsFactory.KEY_HASH_COLLISION, Call.BULK);
-                            }                            
-                            final CachedData cd = new CachedData(val.getFlags(), val.getValue(), CachedData.MAX_SIZE);
-                            if(tc == null) {
-                                returnVal.put(val.getKey(), (T)evcacheMemcachedClient.getTranscoder().decode(cd));
-                            } else {
-                                returnVal.put(val.getKey(), tc.decode(cd));
-                            }
-                        } else {
-                            if (log.isDebugEnabled()) log.debug("Value for key : " + entry.getKey() + " is not EVCacheValue. val : " + obj);
-                        }
-                    }
-                } else {
-                    return Collections.<String, T> emptyMap();
-                }
             } else {
                 returnVal = evcacheMemcachedClient.asyncGetBulk(canonicalKeys, tc, null)
                         .getSome(bulkReadTimeout.get(), TimeUnit.MILLISECONDS, _throwException, hasZF);
@@ -1096,39 +961,6 @@ public class EVCacheClient {
             final Transcoder<T> tc = (transcoder == null) ? (Transcoder<T>) getTranscoder() : transcoder;
             if (enableChunking.get()) {
                 return assembleChunks(_canonicalKeys, tc, hasZF, scheduler);
-            } else if(shouldHashKey()) {
-                final Collection<String> hashKeys = new ArrayList<String>(canonicalKeys.size());
-                final HashMap<String, T> returnVal = new HashMap<String, T>();
-                for(String cKey : canonicalKeys) {
-                    final String hKey = getHashedKey(cKey);
-                    hashKeys.add(hKey);
-                    returnVal.compute(cKey, null);
-                }
-                final Single<Map<String, Object>> vals = evcacheMemcachedClient.asyncGetBulk(hashKeys, evcacheValueTranscoder, null).getSome(bulkReadTimeout.get(), TimeUnit.MILLISECONDS, _throwException, hasZF, scheduler);
-                if(vals != null ) {
-                    return vals.flatMap(r -> {
-                        for(Entry<String, Object> entry : r.entrySet()) {
-                            final Object obj = entry.getValue();
-                            if(obj instanceof EVCacheValue) {
-                                final EVCacheValue val = (EVCacheValue)obj;
-                                if(val == null || !(returnVal.containsKey(val.getKey()))) {
-                                    incrementFailure(EVCacheMetricsFactory.KEY_HASH_COLLISION, Call.BULK);
-                                }
-                                final CachedData cd = new CachedData(val.getFlags(), val.getValue(), CachedData.MAX_SIZE);
-                                if(tc == null) {
-                                    returnVal.put(val.getKey(), (T)evcacheMemcachedClient.getTranscoder().decode(cd));
-                                } else {
-                                    returnVal.put(val.getKey(), tc.decode(cd));
-                                }
-                            } else {
-                                if (log.isDebugEnabled()) log.debug("Value for key : " + entry.getKey() + " is not EVCacheValue. val : " + obj);
-                            }
-                        }
-                        return Single.just(returnVal);
-                    });
-                } else {
-                    return Single.just(Collections.<String, T> emptyMap());
-                }
             } else {
                 return evcacheMemcachedClient.asyncGetBulk(canonicalKeys, tc, null)
                     .getSome(bulkReadTimeout.get(), TimeUnit.MILLISECONDS, _throwException, hasZF, scheduler);
@@ -1143,12 +975,7 @@ public class EVCacheClient {
                 "This operation is not supported as chunking is enabled on this EVCacheClient.");
         final MemcachedNode node = evcacheMemcachedClient.getEVCacheNode(key);
         if (!ensureWriteQueueSize(node, key, Call.APPEND)) return getDefaultFuture();
-        if(shouldHashKey()) {
-            final String hKey = getHashedKey(key);
-            return evcacheMemcachedClient.append(hKey, value);
-        } else {
-            return evcacheMemcachedClient.append(key, value);
-        }
+        return evcacheMemcachedClient.append(key, value);
     }
 
     public Future<Boolean> set(String key, CachedData value, int timeToLive) throws Exception {
@@ -1206,10 +1033,6 @@ public class EVCacheClient {
                     delete(key);
                     return evcacheMemcachedClient.set(key, timeToLive, value, null, evcacheLatch);
                 }
-            } else if(shouldHashKey()) {
-                final String hKey = getHashedKey(key);
-                final CachedData cVal = getEVCacheValue(key, value, timeToLive);
-                return evcacheMemcachedClient.set(hKey, timeToLive, cVal, null, evcacheLatch);
             } else {
                 return evcacheMemcachedClient.set(key, timeToLive, value, null, evcacheLatch);
             }
@@ -1219,17 +1042,12 @@ public class EVCacheClient {
         }
     }
 
-    protected CachedData getEVCacheValue(String key, CachedData cData, int timeToLive) {
-        final EVCacheValue val = new EVCacheValue(key, cData.getData(), cData.getFlags(), timeToLive, System.currentTimeMillis());
-        return evcacheValueTranscoder.encode(val);
-    }
-
     protected boolean shouldHashKey() {
-        return (!hashKeyByApp.get() && hashKeyByServerGroup.get());
+        return hashKeyByServerGroup.get();
     }
 
-    protected String getHashedKey(String key) {
-        return KeyHasher.getHashedKey(key, hashingAlgo.get());
+    public HashingAlgorithm getHashingAlgorithm() {
+        return shouldHashKey() ? KeyHasher.getHashingAlgorithmFromString(hashingAlgo.get()) : null;
     }
 
     public <T> Future<Boolean> appendOrAdd(String key, CachedData value, int timeToLive, EVCacheLatch evcacheLatch) throws Exception {
@@ -1284,10 +1102,6 @@ public class EVCacheClient {
                     futures[i] = evcacheMemcachedClient.replace(key + "_" + prefix + i, timeToLive, cd[i], null, null);
                 }
                 return new EVCacheFutures(futures, key, appName, serverGroup, evcacheLatch);
-            } else if(shouldHashKey()) {
-                final String hKey = getHashedKey(key);
-                final CachedData cVal = getEVCacheValue(key, value, timeToLive);
-                return evcacheMemcachedClient.replace(hKey, timeToLive, cVal, null, evcacheLatch);
             } else {
                 return evcacheMemcachedClient.replace(key, timeToLive, value, null, evcacheLatch);
             }
@@ -1302,13 +1116,7 @@ public class EVCacheClient {
 
         final MemcachedNode node = evcacheMemcachedClient.getEVCacheNode(key);
         if (!ensureWriteQueueSize(node, key, Call.ADD)) return getDefaultFuture();
-        if(shouldHashKey()) {
-            final String hKey = getHashedKey(key);
-            final CachedData cVal = getEVCacheValue(key, value, exp);
-            return evcacheMemcachedClient.add(hKey, exp, cVal, null, latch);
-        } else {
-            return evcacheMemcachedClient.add(key, exp, value, null, latch);
-        }
+        return evcacheMemcachedClient.add(key, exp, value, null, latch);
     }
 
     @Deprecated
@@ -1388,9 +1196,6 @@ public class EVCacheClient {
             } else {
                 return evcacheMemcachedClient.touch(key, timeToLive, latch);
             }
-        } else if(shouldHashKey()) {
-            final String hKey = getHashedKey(key);
-            return evcacheMemcachedClient.touch(hKey, timeToLive, latch);
         } else {
             return evcacheMemcachedClient.touch(key, timeToLive, latch);
         }
@@ -1402,12 +1207,7 @@ public class EVCacheClient {
                 "This operation is not supported as chunking is enabled on this EVCacheClient.");
         if (!validateNode(key, _throwException, Call.ASYNC_GET)) return null;
         if (tc == null) tc = (Transcoder<T>) getTranscoder();
-        if(shouldHashKey()) {
-            final String hKey = getHashedKey(key);
-            return evcacheMemcachedClient.asyncGet(hKey, tc, null);
-        } else {
-            return evcacheMemcachedClient.asyncGet(key, tc, null);
-        }
+        return evcacheMemcachedClient.asyncGet(key, tc, null);
     }
 
     public Future<Boolean> delete(String key) throws Exception {
@@ -1439,9 +1239,6 @@ public class EVCacheClient {
                 }
                 return new EVCacheFutures(futures, key, appName, serverGroup, latch);
             }
-        } else if(shouldHashKey()) {
-            final String hKey = getHashedKey(key);
-            return evcacheMemcachedClient.delete(hKey, latch);
         } else {
             return evcacheMemcachedClient.delete(key, latch);
         }
@@ -1926,41 +1723,15 @@ public class EVCacheClient {
 
 
     public EVCacheItemMetaData metaDebug(String key) throws Exception {
-        if(shouldHashKey()) {
-            key = getHashedKey(key);
-        }
         final EVCacheItemMetaData obj = evcacheMemcachedClient.metaDebug(key);
         if(log.isDebugEnabled()) log.debug("EVCacheItemMetaData : " + obj);
         return obj;
     }
 
     public <T> EVCacheItem<T> metaGet(String key, Transcoder<T> tc, boolean _throwException, boolean hasZF) throws Exception {
-        if(shouldHashKey()) {
-            final String hKey = getHashedKey(key);
-            final EVCacheItem<Object> obj = evcacheMemcachedClient.asyncMetaGet(hKey, evcacheValueTranscoder, null).get(readTimeout.get(), TimeUnit.MILLISECONDS, _throwException, hasZF);
-            if(obj.getData() instanceof EVCacheValue) {
-                final EVCacheValue val = (EVCacheValue)obj.getData();
-                if(val == null || !(val.getKey().equals(key))) {
-                    incrementFailure(EVCacheMetricsFactory.KEY_HASH_COLLISION, Call.GET);
-                    return null;
-                }
-                final CachedData cd = new CachedData(val.getFlags(), val.getValue(), CachedData.MAX_SIZE);
-                T t = null;
-                if(tc == null) {
-                    t = (T)evcacheMemcachedClient.getTranscoder().decode(cd);
-                } else {
-                    t = tc.decode(cd);
-                }
-                obj.setData(t);
-                obj.setFlag(val.getFlags());
-                return (EVCacheItem<T>) obj;
-            } else 
-                return null;
-        } else {
-            final EVCacheItem<T> obj = evcacheMemcachedClient.asyncMetaGet(key, tc, null).get(readTimeout.get(), TimeUnit.MILLISECONDS, _throwException, hasZF);
-            if(log.isDebugEnabled()) log.debug("EVCacheItem : " + obj);
-            return obj;
-        }
+        final EVCacheItem<T> obj = evcacheMemcachedClient.asyncMetaGet(key, tc, null).get(readTimeout.get(), TimeUnit.MILLISECONDS, _throwException, hasZF);
+        if (log.isDebugEnabled()) log.debug("EVCacheItem : " + obj);
+        return obj;
     }
 
 

--- a/evcache-core/src/main/java/com/netflix/evcache/pool/EVCacheClient.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/pool/EVCacheClient.java
@@ -89,6 +89,8 @@ public class EVCacheClient {
     private final Property<Boolean> ignoreInactiveNodes;
     private final Property<Boolean> enableChunking;
     private final Property<Boolean> hashKeyByServerGroup;
+    private final Property<Boolean> shouldEncodeHashKey;
+    private final Property<Integer> maxHashingBytes;
     private final Property<Integer> chunkSize, writeBlock;
     private final ChunkTranscoder chunkingTranscoder;
     private final SerializingTranscoder decodingTranscoder;
@@ -148,6 +150,8 @@ public class EVCacheClient {
 
         this.hashKeyByServerGroup = EVCacheConfig.getInstance().getPropertyRepository().get(this.serverGroup.getName() + ".hash.key", Boolean.class).orElse(false);
         this.hashingAlgo = EVCacheConfig.getInstance().getPropertyRepository().get(this.serverGroup.getName() + ".hash.algo", String.class).orElseGet(appName + ".hash.algo").orElse("siphash24");
+        this.shouldEncodeHashKey = EVCacheConfig.getInstance().getPropertyRepository().get(this.serverGroup.getName() + ".hash.encode", Boolean.class).orElse(null);
+        this.maxHashingBytes = EVCacheConfig.getInstance().getPropertyRepository().get(this.serverGroup.getName() + ".hash.max.bytes", Integer.class).orElse(null);
         ping();
     }
 
@@ -164,6 +168,14 @@ public class EVCacheClient {
     
     public boolean isDuetClient() {
         return isDuetClient;
+    }
+
+    public Boolean shouldEncodeHashKey() {
+        return this.shouldEncodeHashKey.get();
+    }
+
+    public Integer getMaxHashingBytes() {
+        return this.maxHashingBytes.get();
     }
 
     private Collection<String> validateReadQueueSize(Collection<String> canonicalKeys, EVCache.Call call) throws EVCacheException {
@@ -1042,7 +1054,7 @@ public class EVCacheClient {
         }
     }
 
-    protected boolean shouldHashKey() {
+    private boolean shouldHashKey() {
         return hashKeyByServerGroup.get();
     }
 

--- a/evcache-core/src/main/java/com/netflix/evcache/pool/EVCacheClientUtil.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/pool/EVCacheClientUtil.java
@@ -25,27 +25,26 @@ public class EVCacheClientUtil {
         this._appName = pool.getAppName();
     }
 
+    //TODO: Remove this todo. This method has been made hashing agnostic.
     /**
      * TODO : once metaget is available we need to get the remaining ttl from an existing entry and use it 
      */
-    public EVCacheLatch add(EVCacheKey evcKey, final CachedData cd, boolean shouldHashKey, Transcoder evcacheValueTranscoder, int timeToLive, Policy policy) throws Exception {
+    public EVCacheLatch add(EVCacheKey evcKey, final CachedData cd, Transcoder evcacheValueTranscoder, int timeToLive, Policy policy) throws Exception {
         if (cd == null) return null; 
         
         final EVCacheClient[] clients = _pool.getEVCacheClientForWrite();
         final EVCacheLatchImpl latch = new EVCacheLatchImpl(policy, clients.length - _pool.getWriteOnlyEVCacheClients().length, _appName);
 
-        CachedData cd1 = null;
         Boolean firstStatus = null;
         for (EVCacheClient client : clients) {
-            String key = evcKey.getDerivedKey(client.isDuetClient());
-            if (shouldHashKey) {
-            	if(cd1 == null) {
-	                final EVCacheValue val = new EVCacheValue(evcKey.getCanonicalKey(client.isDuetClient()), cd.getData(), cd.getFlags(), timeToLive, System.currentTimeMillis());
-	                cd1 = evcacheValueTranscoder.encode(val);
-            	}
+            CachedData cd1 = null;
+            if (evcKey.getHashKey(client.isDuetClient(), client.getHashingAlgorithm()) != null) {
+                final EVCacheValue val = new EVCacheValue(evcKey.getCanonicalKey(client.isDuetClient()), cd.getData(), cd.getFlags(), timeToLive, System.currentTimeMillis());
+                cd1 = evcacheValueTranscoder.encode(val);
             } else {
             	cd1 = cd;
             }
+            String key = evcKey.getDerivedKey(client.isDuetClient(), client.getHashingAlgorithm());
             final Future<Boolean> f = client.add(key, timeToLive, cd1, latch);
             if (log.isDebugEnabled()) log.debug("ADD : Op Submitted : APP " + _appName + ", key " + key + "; future : " + f + "; client : " + client);
             boolean status = f.get().booleanValue();
@@ -67,12 +66,12 @@ public class EVCacheClientUtil {
     private EVCacheLatch fixup(EVCacheClient sourceClient, EVCacheClient[] destClients, EVCacheKey evcKey, int timeToLive, Policy policy) {
         final EVCacheLatchImpl latch = new EVCacheLatchImpl(policy, destClients.length, _appName);
         try {
-            final CachedData readData = sourceClient.get(evcKey.getDerivedKey(sourceClient.isDuetClient()), ct, false, false);
+            final CachedData readData = sourceClient.get(evcKey.getDerivedKey(sourceClient.isDuetClient(), sourceClient.getHashingAlgorithm()), ct, false, false);
 
             if(readData != null) {
-                sourceClient.touch(evcKey.getDerivedKey(sourceClient.isDuetClient()), timeToLive);
+                sourceClient.touch(evcKey.getDerivedKey(sourceClient.isDuetClient(), sourceClient.getHashingAlgorithm()), timeToLive);
                 for(EVCacheClient destClient : destClients) {
-                    destClient.set(evcKey.getDerivedKey(destClient.isDuetClient()), readData, timeToLive, latch);
+                    destClient.set(evcKey.getDerivedKey(destClient.isDuetClient(), destClient.getHashingAlgorithm()), readData, timeToLive, latch);
                 }
             }
             latch.await(_pool.getOperationTimeout().get(), TimeUnit.MILLISECONDS);

--- a/evcache-core/src/main/java/com/netflix/evcache/util/KeyHasher.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/util/KeyHasher.java
@@ -13,7 +13,6 @@ import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 
 public class KeyHasher {
-
     /**
      * meta data size 
      * 40 + key + 'item_hdr' size
@@ -24,9 +23,30 @@ And if client flags are present:
 And if CAS and client flags are present:
 40 + keysize + 4 bytes(for flags) + 8(for CAS) + 12
      */
-    
-    
-    
+
+    public enum HashingAlgorithm {
+        murmur3,
+        adler32,
+        crc32,
+        sha1,
+        sha256,
+        siphash24,
+        goodfasthash,
+        md5
+    }
+
+    public static HashingAlgorithm getHashingAlgorithmFromString(String algorithmStr) {
+        try {
+            if (null == algorithmStr || algorithmStr.isEmpty()) {
+                return null;
+            }
+            return HashingAlgorithm.valueOf(algorithmStr.toLowerCase());
+        } catch (IllegalArgumentException ex) {
+            // default to md5 incase of unsupported algorithm
+            return HashingAlgorithm.md5;
+        }
+    }
+
     private static final Logger log = LoggerFactory.getLogger(KeyHasher.class);
     private static final Encoder encoder= Base64.getEncoder().withoutPadding();
 
@@ -45,40 +65,40 @@ And if CAS and client flags are present:
 //        }
 //    }
 
-    public static String getHashedKey(String key, String hashingAlgorithm) {
+    public static String getHashedKey(String key, HashingAlgorithm hashingAlgorithm) {
         final long start = System.nanoTime();
-        HashFunction hf = null; 
-        switch(hashingAlgorithm.toLowerCase()) {
-            case "murmur3" :
+        HashFunction hf = null;
+        switch (hashingAlgorithm) {
+            case murmur3:
                 hf = Hashing.murmur3_128();
                 break;
-    
-            case "adler32" :
+
+            case adler32:
                 hf = Hashing.adler32();
                 break;
-    
-            case "crc32" :
+
+            case crc32:
                 hf = Hashing.crc32();
                 break;
-    
-            case "sha1" :
+
+            case sha1:
                 hf = Hashing.sha1();
                 break;
-    
-            case "sha256" :
+
+            case sha256:
                 hf = Hashing.sha256();
                 break;
-    
-            case "siphash24" :
+
+            case siphash24:
                 hf = Hashing.sipHash24();
                 break;
 
-            case "goodfasthash" :
+            case goodfasthash:
                 hf = Hashing.goodFastHash(128);
                 break;
-    
-            case "md5" :
-            default :
+
+            case md5:
+            default:
                 hf = Hashing.md5();
                 break;
         }

--- a/evcache-zipkin-tracing/src/test/java/com/netflix/evcache/EVCacheTracingEventListenerUnitTests.java
+++ b/evcache-zipkin-tracing/src/test/java/com/netflix/evcache/EVCacheTracingEventListenerUnitTests.java
@@ -40,7 +40,7 @@ public class EVCacheTracingEventListenerUnitTests {
     when(mockEVCacheEvent.getAppName()).thenReturn("dummyAppName");
     when(mockEVCacheEvent.getCacheName()).thenReturn("dummyCacheName");
     when(mockEVCacheEvent.getEVCacheKeys())
-        .thenReturn(Arrays.asList(new EVCacheKey("dummyAppName", "dummyKey", "dummyCanonicalKey", null)));
+        .thenReturn(Arrays.asList(new EVCacheKey("dummyAppName", "dummyKey", "dummyCanonicalKey", null, null, null)));
     when(mockEVCacheEvent.getStatus()).thenReturn("success");
     when(mockEVCacheEvent.getDurationInMillis()).thenReturn(1L);
     when(mockEVCacheEvent.getTTL()).thenReturn(0);

--- a/evcache-zipkin-tracing/src/test/java/com/netflix/evcache/EVCacheTracingEventListenerUnitTests.java
+++ b/evcache-zipkin-tracing/src/test/java/com/netflix/evcache/EVCacheTracingEventListenerUnitTests.java
@@ -40,7 +40,7 @@ public class EVCacheTracingEventListenerUnitTests {
     when(mockEVCacheEvent.getAppName()).thenReturn("dummyAppName");
     when(mockEVCacheEvent.getCacheName()).thenReturn("dummyCacheName");
     when(mockEVCacheEvent.getEVCacheKeys())
-        .thenReturn(Arrays.asList(new EVCacheKey("dummyAppName", "dummyKey", "dummyCanonicalKey", null, null)));
+        .thenReturn(Arrays.asList(new EVCacheKey("dummyAppName", "dummyKey", "dummyCanonicalKey", null)));
     when(mockEVCacheEvent.getStatus()).thenReturn("success");
     when(mockEVCacheEvent.getDurationInMillis()).thenReturn(1L);
     when(mockEVCacheEvent.getTTL()).thenReturn(0);


### PR DESCRIPTION
EVCacheKey class handles the logic of overlaying hashing of app level and EVCacheClient level, making it possible for EVCacheImpl to take the hashing decision at both the levels, and thereby removing hashing logic from EVCacheClient