### PR TITLE
Adding support for making duet as a primary

### DIFF
--- a/evcache-core/src/main/java/net/spy/memcached/EVCacheNode.java
+++ b/evcache-core/src/main/java/net/spy/memcached/EVCacheNode.java
@@ -3,6 +3,7 @@ package net.spy.memcached;
 import java.util.List;
 
 import com.netflix.evcache.EVCache;
+import com.netflix.evcache.pool.EVCacheClient;
 import com.netflix.evcache.pool.ServerGroup;
 import com.netflix.spectator.api.Tag;
 
@@ -58,5 +59,7 @@ public interface EVCacheNode extends MemcachedNode {
     int getReconnectCount();
 
     boolean isActive();
+    
+    EVCacheClient getEVCacheClient();
 
 }

--- a/evcache-core/src/main/java/net/spy/memcached/protocol/ascii/EVCacheAsciiNodeImpl.java
+++ b/evcache-core/src/main/java/net/spy/memcached/protocol/ascii/EVCacheAsciiNodeImpl.java
@@ -230,4 +230,8 @@ public class EVCacheAsciiNodeImpl extends TCPMemcachedNodeImpl implements EVCach
   }
   
   
+	@Override
+	public EVCacheClient getEVCacheClient() {
+		return client;
+	}
 }

--- a/evcache-core/src/main/java/net/spy/memcached/protocol/binary/EVCacheNodeImpl.java
+++ b/evcache-core/src/main/java/net/spy/memcached/protocol/binary/EVCacheNodeImpl.java
@@ -325,4 +325,9 @@ public class EVCacheNodeImpl extends BinaryMemcachedNodeImpl implements EVCacheN
     public String getConnectTime() {
         return ISODateTimeFormat.dateTime().print(stTime);
     }
+
+	@Override
+	public EVCacheClient getEVCacheClient() {
+		return client;
+	}
 }


### PR DESCRIPTION
This PR has majorly two changes

- Provides ability to make duet as primary, in which case, duet is given preference over the actual application for reads/writes. If duet happens to be unavailable, we fall back to the actual application.
- Non-primary application's ASGs are counted as write-only, thereby, client does not need to wait for the ack from non-primary  ASGs for writes.