### PR TITLE
Replace JCenter with Maven Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   repositories {
-    jcenter()
+    mavenCentral()
   }
 }
 
@@ -15,7 +15,7 @@ subprojects {
     group = "com.netflix.evcache"
 
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     sourceCompatibility = 1.8

--- a/evcache-client-sample/build.gradle
+++ b/evcache-client-sample/build.gradle
@@ -1,9 +1,8 @@
 apply plugin: 'java'
 
 repositories {
-        jcenter()
-        mavenLocal()
-        mavenCentral()
+    mavenCentral()
+    mavenLocal()
 }
 
 configurations.all {

--- a/evcache-core/build.gradle
+++ b/evcache-core/build.gradle
@@ -7,8 +7,7 @@ sourceSets.test.java.srcDir 'src/test/java'
 
 repositories {
         mavenLocal()
-        jcenter()
-        mavenCentral() // maven { url 'http://jcenter.bintray.com' }
+        mavenCentral()
 }
 
 test {

--- a/evcache-zipkin-tracing/build.gradle
+++ b/evcache-zipkin-tracing/build.gradle
@@ -5,7 +5,7 @@ sourceSets.test.java.srcDir 'src/test/java'
 
 repositories {
     mavenLocal()
-    mavenCentral() // maven { url 'http://jcenter.bintray.com' }
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
This replaces jcenter with maven central to avoid broken builds in the future

