### PR TITLE
EVCACHE-454: allow to ignore eureka status of application. 

### DIFF
--- a/evcache-client/src/main/java/com/netflix/evcache/pool/eureka/EurekaNodeListProvider.java
+++ b/evcache-client/src/main/java/com/netflix/evcache/pool/eureka/EurekaNodeListProvider.java
@@ -56,7 +56,14 @@ public class EurekaNodeListProvider implements EVCacheNodeList {
      */
     @Override
     public Map<ServerGroup, EVCacheServerGroupConfig> discoverInstances(String _appName) throws IOException {
-        if ((applicationInfoManager.getInfo().getStatus() == InstanceStatus.DOWN)) {
+        final Property<Boolean> ignoreAppEurekaStatus = props.get("evcache.ignoreAppEurekaStatus", Boolean.class).orElse(false);
+
+        if (ignoreAppEurekaStatus.get())
+            log.info("Not going to consider the eureka status of the application, to initialize evcache client.");
+
+        if (!ignoreAppEurekaStatus.get() && (applicationInfoManager.getInfo().getStatus() == InstanceStatus.DOWN)) {
+            log.info("Not initializing evcache client as application eureka status is DOWN. " +
+                    "One can override this behavior by setting evcache.ignoreAppEurekaStatus on application.");
             return Collections.<ServerGroup, EVCacheServerGroupConfig> emptyMap();
         }
 

--- a/evcache-client/src/main/java/com/netflix/evcache/pool/eureka/EurekaNodeListProvider.java
+++ b/evcache-client/src/main/java/com/netflix/evcache/pool/eureka/EurekaNodeListProvider.java
@@ -63,7 +63,7 @@ public class EurekaNodeListProvider implements EVCacheNodeList {
 
         if (!ignoreAppEurekaStatus.get() && (applicationInfoManager.getInfo().getStatus() == InstanceStatus.DOWN)) {
             log.info("Not initializing evcache client as application eureka status is DOWN. " +
-                    "One can override this behavior by setting evcache.ignoreAppEurekaStatus on application.");
+                    "One can override this behavior by setting evcache.ignoreAppEurekaStatus property to true, scoped to your application.");
             return Collections.<ServerGroup, EVCacheServerGroupConfig> emptyMap();
         }
 


### PR DESCRIPTION
Ideally, the app should not serve traffic until it is healthy but this option - ignoreAppEurekaStatus will allow the app to ignore application eureka status while trying to initialize evcache client. This feature `may` be required for applications that are behind load balancers. They may fail to register successfully with eureka but are still expected to serve traffic.