### PR TITLE
Automatically switch logs to DEBUG on client wrong key error

### DIFF
--- a/evcache-core/src/main/java/net/spy/memcached/EVCacheMemcachedClient.java
+++ b/evcache-core/src/main/java/net/spy/memcached/EVCacheMemcachedClient.java
@@ -76,7 +76,7 @@ public class EVCacheMemcachedClient extends MemcachedClient {
     private Property<Long> mutateOperationTimeout;
     private final ConnectionFactory connectionFactory;
     private final Property<Integer> maxReadDuration, maxWriteDuration;
-    private final Property<Boolean> autoLogSwitchOnWrongKey;
+    private final Property<Boolean> enableDebugLogsOnWrongKey;
 
     public EVCacheMemcachedClient(ConnectionFactory cf, List<InetSocketAddress> addrs,
                                   Property<Integer> readTimeout, EVCacheClient client) throws IOException {
@@ -87,7 +87,7 @@ public class EVCacheMemcachedClient extends MemcachedClient {
         this.appName = client.getAppName();
         this.maxWriteDuration = EVCacheConfig.getInstance().getPropertyRepository().get(appName + ".max.write.duration.metric", Integer.class).orElseGet("evcache.max.write.duration.metric").orElse(50);
         this.maxReadDuration = EVCacheConfig.getInstance().getPropertyRepository().get(appName + ".max.read.duration.metric", Integer.class).orElseGet("evcache.max.read.duration.metric").orElse(20);
-        this.autoLogSwitchOnWrongKey = EVCacheConfig.getInstance().getPropertyRepository().get(appName + ".enable.auto.log.switch", Boolean.class).orElse(false);
+        this.enableDebugLogsOnWrongKey = EVCacheConfig.getInstance().getPropertyRepository().get(appName + ".enable.debug.logs.on.wrongkey", Boolean.class).orElse(false);
     }
 
     public NodeLocator getNodeLocator() {
@@ -115,8 +115,8 @@ public class EVCacheMemcachedClient extends MemcachedClient {
             client.reportWrongKeyReturned(original_host);
 
             // If we are configured to dynamically switch log levels to DEBUG on a wrong key error, do so here.
-            if (autoLogSwitchOnWrongKey.get()) {
-                org.apache.log4j.Logger.getRootLogger().setLevel(org.apache.log4j.Level.toLevel("DEBUG"));
+            if (enableDebugLogsOnWrongKey.get()) {
+                System.setProperty("log4j.logger.net.spy.memcached", "DEBUG");
             }
             return true;
         }


### PR DESCRIPTION
New Boolean FP to control log switching:
<appName>.enable.auto.log.switch

NOTE: This is only a temporary commit to help catch a bug. This
will be reverted once we've fixed the underlying bug.