### PR TITLE
use FP to choose if optimize broadcast

### DIFF
--- a/evcache-core/src/main/java/com/netflix/evcache/connection/BaseAsciiConnectionFactory.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/connection/BaseAsciiConnectionFactory.java
@@ -139,7 +139,7 @@ public class BaseAsciiConnectionFactory extends DefaultConnectionFactory {
     }
 
     public boolean shouldOptimize() {
-        return true;
+        return EVCacheConfig.getInstance().getPropertyRepository().get("evcache.broadcast.ascii.connection.optimize", Boolean.class).orElse(true).get();
     }
 
     public boolean isDefaultExecutorService() {

--- a/evcache-core/src/main/java/com/netflix/evcache/connection/BaseConnectionFactory.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/connection/BaseConnectionFactory.java
@@ -133,7 +133,7 @@ public class BaseConnectionFactory extends BinaryConnectionFactory {
     }
 
     public boolean shouldOptimize() {
-        return true;
+        return EVCacheConfig.getInstance().getPropertyRepository().get("evcache.broadcast.base.connection.optimize", Boolean.class).orElse(true).get();
     }
 
     public boolean isDefaultExecutorService() {


### PR DESCRIPTION
Thanks for the fix.

Context:
we are mutating a strings collection while iterating over the collection. This happens specifically during the addOperation as part of OptimizedGetImpl.java
