### PR TITLE
 Pin Testng version to 7.5 

### DIFF
--- a/evcache-client/build.gradle
+++ b/evcache-client/build.gradle
@@ -32,9 +32,8 @@ dependencies {
         compile group:"org.json",                     name:"json",                             version:"20180813"
         
 
-        testCompile group:"org.testng",               name:"testng",                           version:"7.+"
+        testCompile group:"org.testng",               name:"testng",                           version:"7.5"
         testCompile group:"com.netflix.archaius",     name:"archaius2-guice",                  version:"latest.release"
-        testCompile group:"org.testng",               name:"testng",                           version:"latest.release"
         testCompile group:"com.beust",                name:"jcommander",                       version:"1.72"
         testCompile group:"org.mockito",              name:"mockito-all",                      version:"latest.release"
         testCompile group:'org.assertj',              name:'assertj-core',                     version:'latest.release'

--- a/evcache-core/build.gradle
+++ b/evcache-core/build.gradle
@@ -39,7 +39,7 @@ dependencies {
         compile group:"javax.annotation",             name:"javax.annotation-api",             version:"latest.release"
         compile group:"com.github.fzakaria",          name:"ascii85",                          version:"latest.release"
 
-        testCompile group:"org.testng",               name:"testng",                           version:"latest.release"
+        testCompile group:"org.testng",               name:"testng",                           version:"7.5"
         testCompile group:"com.beust",                name:"jcommander",                       version:"1.72"
         testCompile group:"org.mockito",              name:"mockito-all",                      version:"latest.release"	
         testCompile group:'org.assertj',              name:'assertj-core',                     version:'latest.release'

--- a/evcache-zipkin-tracing/build.gradle
+++ b/evcache-zipkin-tracing/build.gradle
@@ -11,7 +11,7 @@ repositories {
 dependencies {
     compile project(':evcache-core')
     compile group:"io.zipkin.brave", name:"brave", version:"5.12.7"
-    testCompile group:"org.testng", name:"testng", version:"7.+"
+    testCompile group:"org.testng", name:"testng", version:"7.5"
     testCompile group:"org.mockito", name:"mockito-all", version:"latest.release"
 }
 


### PR DESCRIPTION
Context: 
With the latest TestNg 7.6.0 the build was broken with following error 
Could not resolve org.testng:testng:7.+.
     Required by:
         project :evcache-client
      > No matching variant of org.testng:testng:7.6.0 was found. The consumer was configured to find an API of a library compatible with Java 8, preferably in the form of class files, and its dependencies declared externally but:
          - Variant 'antApiElements' capability org.testng:testng-ant:7.6.0 declares an API of a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component compatible with Java 11 and the consumer needed a component compatible with Java 8
          - Variant 'antRuntimeElements' capability org.testng:testng-ant:7.6.0 declares a runtime of a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component compatible with Java 11 and the consumer needed a component compatible with Java 8
          - Variant 'apiElements' capability org.testng:testng:7.6.0 declares an API of a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component compatible with Java 11 and the consumer needed a component compatible with Java 8
          - Variant 'guiceApiElements' capability org.testng:testng-guice:7.6.0 declares an API of a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component compatible with Java 11 and the consumer needed a component compatible with Java 8
          - Variant 'guiceRuntimeElements' capability org.testng:testng-guice:7.6.0 declares a runtime of a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component compatible with Java 11 and the consumer needed a component compatible with Java 8
          - Variant 'javadocElements' capability org.testng:testng:7.6.0 declares a runtime of a component, and its dependencies declared externally:
              - Incompatible because this component declares documentation and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
                  - Doesn't say anything about its elements (required them preferably in the form of class files)
          - Variant 'junitApiElements' capability org.testng:testng-junit:7.6.0 declares an API of a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component compatible with Java 11 and the consumer needed a component compatible with Java 8
          - Variant 'junitRuntimeElements' capability org.testng:testng-junit:7.6.0 declares a runtime of a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component compatible with Java 11 and the consumer needed a component compatible with Java 8
          - Variant 'runtimeElements' capability org.testng:testng:7.6.0 declares a runtime of a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component compatible with Java 11 and the consumer needed a component compatible with Java 8
          - Variant 'sourcesElements' capability org.testng:testng:7.6.0 declares a runtime of a component, and its dependencies declared externally:
              - Incompatible because this component declares documentation and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
                  - Doesn't say anything about its elements (required them preferably in the form of class files)
          - Variant 'yamlApiElements' capability org.testng:testng-yaml:7.6.0 declares an API of a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component compatible with Java 11 and the consumer needed a component compatible with Java 8
          - Variant 'yamlRuntimeElements' capability org.testng:testng-yaml:7.6.0 declares a runtime of a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component compatible with Java 11 and the consumer needed a component compatible with Java 8
   > Could not resolve org.testng:testng:latest.release.
     Required by:
         project :evcache-client
      > No matching variant of org.testng:testng:7.6.0 was found. The consumer was configured to find an API of a library compatible with Java 8, preferably in the form of class files, and its dependencies declared externally but:
          - Variant 'antApiElements' capability org.testng:testng-ant:7.6.0 declares an API of a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component compatible with Java 11 and the consumer needed a component compatible with Java 8
          - Variant 'antRuntimeElements' capability org.testng:testng-ant:7.6.0 declares a runtime of a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component compatible with Java 11 and the consumer needed a component compatible with Java 8
          - Variant 'apiElements' capability org.testng:testng:7.6.0 declares an API of a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component compatible with Java 11 and the consumer needed a component compatible with Java 8
          - Variant 'guiceApiElements' capability org.testng:testng-guice:7.6.0 declares an API of a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component compatible with Java 11 and the consumer needed a component compatible with Java 8
          - Variant 'guiceRuntimeElements' capability org.testng:testng-guice:7.6.0 declares a runtime of a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component compatible with Java 11 and the consumer needed a component compatible with Java 8
          - Variant 'javadocElements' capability org.testng:testng:7.6.0 declares a runtime of a component, and its dependencies declared externally:
              - Incompatible because this component declares documentation and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
                  - Doesn't say anything about its elements (required them preferably in the form of class files)
          - Variant 'junitApiElements' capability org.testng:testng-junit:7.6.0 declares an API of a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component compatible with Java 11 and the consumer needed a component compatible with Java 8
          - Variant 'junitRuntimeElements' capability org.testng:testng-junit:7.6.0 declares a runtime of a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component compatible with Java 11 and the consumer needed a component compatible with Java 8
          - Variant 'runtimeElements' capability org.testng:testng:7.6.0 declares a runtime of a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component compatible with Java 11 and the consumer needed a component compatible with Java 8
          - Variant 'sourcesElements' capability org.testng:testng:7.6.0 declares a runtime of a component, and its dependencies declared externally:
              - Incompatible because this component declares documentation and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
                  - Doesn't say anything about its elements (required them preferably in the form of class files)
          - Variant 'yamlApiElements' capability org.testng:testng-yaml:7.6.0 declares an API of a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component compatible with Java 11 and the consumer needed a component compatible with Java 8
          - Variant 'yamlRuntimeElements' capability org.testng:testng-yaml:7.6.0 declares a runtime of a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component compatible with Java 11 and the consumer needed a component compatible with Java 8

Notes from TestNg 7.5 release 
TestNG 7.5 would be the last of the TestNG releases that would run on JDK8. The next TestNG release would have a minimum JDK dependency of JDK11
https://groups.google.com/g/testng-users/c/ESLiK8xSomc?pli=1

Steps: 
./gradlew clean build test --refresh-dependencies

Build passing locally 
BUILD SUCCESSFUL in 1m 15s
48 actionable tasks: 41 executed, 7 up-to-date


              
