### PR TITLE
Change from debug/info to trace for compression

### DIFF
--- a/evcache-core/src/main/java/com/netflix/evcache/EVCacheSerializingTranscoder.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/EVCacheSerializingTranscoder.java
@@ -184,12 +184,12 @@ public class EVCacheSerializingTranscoder extends BaseSerializingTranscoder impl
         if (b.length > compressionThreshold) {
             byte[] compressed = compress(b);
             if (compressed.length < b.length) {
-                getLogger().debug("Compressed %s from %d to %d",
+                getLogger().trace("Compressed %s from %d to %d",
                         o.getClass().getName(), b.length, compressed.length);
                 b = compressed;
                 flags |= COMPRESSED;
             } else {
-                getLogger().info("Compression increased the size of %s from %d to %d",
+                getLogger().trace("Compression increased the size of %s from %d to %d",
                         o.getClass().getName(), b.length, compressed.length);
             }
 


### PR DESCRIPTION
Info logs per compression were affecting performance, reducing logs to trace level.