### PR TITLE
Fix build issues related to missing grgit-core artifact

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,11 @@ buildscript {
   repositories {
     mavenCentral()
   }
+  configurations.all {
+    resolutionStrategy {
+      force 'org.ajoberstar.grgit:grgit-core:4.1.1'
+    }
+  }
 }
 
 plugins {


### PR DESCRIPTION
Force grgit-core to 4.1.1 to resolve build issues. This is a temporary workaround, the ideal solution is to move the project to the latest gradle and netflixoss plugin versions, but that is a larget undertaking.