### PR TITLE
perf: skip future cancellation when not needed

### DIFF
--- a/evcache-core/src/main/java/com/netflix/evcache/EVCacheImpl.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/EVCacheImpl.java
@@ -613,7 +613,6 @@ public class EVCacheImpl implements EVCache, EVCacheImplMBean {
             if (log.isDebugEnabled() && shouldLog()) log.debug("Error while building and starting the event");
             return errorFuture;
         }
-        errorFuture.cancel(false);
 
         final long start = EVCacheMetricsFactory.getInstance().getRegistry().clock().wallTime();
         StringBuilder status = new StringBuilder(EVCacheMetricsFactory.SUCCESS);
@@ -2375,8 +2374,6 @@ public class EVCacheImpl implements EVCache, EVCacheImplMBean {
             if (log.isDebugEnabled() && shouldLog()) log.debug("Error while building and starting the event for doAsyncGetBulk");
             return errorFuture;
         }
-        if (log.isDebugEnabled() && shouldLog()) log.debug("Cancelling the error future");
-        errorFuture.cancel(false);
 
         final long start = EVCacheMetricsFactory.getInstance().getRegistry().clock().wallTime();
         StringBuilder status = new StringBuilder(EVCacheMetricsFactory.SUCCESS);


### PR DESCRIPTION
It implicitly throws an expensive exception. Some codepaths throw away the errorFuture, so there is no need to issue the cancel/throw the exception.

This is approximately half of the CPU overhead on the caller thread for the `getAsync` call.

![image](https://github.com/user-attachments/assets/347ecc46-dcd2-4c88-9c37-fc9a3cbcfd2a)
