### PR TITLE
Enhance log for key size check

### DIFF
--- a/evcache-client/test/com/netflix/evcache/test/EVCacheTestDI.java
+++ b/evcache-client/test/com/netflix/evcache/test/EVCacheTestDI.java
@@ -94,6 +94,8 @@ public class EVCacheTestDI extends DIBase implements EVCacheGetOperationListener
             } catch(Exception e) {
                 exceptionThrown = true;
                 if (log.isDebugEnabled()) log.debug("Check key length: " + longKey  + ": INVALID");
+                assertTrue(e.getMessage().contains(longKey), "Error message should include the invalid key.");
+                assertTrue(e.getMessage().contains(Integer.toString(longKey.length())), "Error message should include the key length of the invalid key.");
             }
             assertTrue(exceptionThrown);
         }

--- a/evcache-core/src/main/java/com/netflix/evcache/EVCacheImpl.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/EVCacheImpl.java
@@ -215,7 +215,9 @@ public class EVCacheImpl implements EVCache, EVCacheImplMBean {
         }
 
         if (canonicalKey.length() > this.maxKeyLength.get() && !hashKey.get() && !autoHashKeys.get()) {
-            throw new IllegalArgumentException("Key is too long (maxlen = " + this.maxKeyLength.get() + ')');
+            final String errMsg = "CanonicalKey ``" + canonicalKey + "`` is too long (maxLen = " + this.maxKeyLength.get() + ", keyLen = " + key.length() + ", canonicalKeyLen = " + canonicalKey.length() + ')';
+            log.error(errMsg);
+            throw new IllegalArgumentException(errMsg);
         }
 
         boolean shouldHashKeyAtAppLevel = hashKey.get() || (canonicalKey.length() > this.maxKeyLength.get() && autoHashKeys.get());

--- a/evcache-core/src/main/java/com/netflix/evcache/EVCacheImpl.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/EVCacheImpl.java
@@ -215,8 +215,8 @@ public class EVCacheImpl implements EVCache, EVCacheImplMBean {
         }
 
         if (canonicalKey.length() > this.maxKeyLength.get() && !hashKey.get() && !autoHashKeys.get()) {
-            final String errMsg = "CanonicalKey ``" + canonicalKey + "`` is too long (maxLen = " + this.maxKeyLength.get() + ", keyLen = " + key.length() + ", canonicalKeyLen = " + canonicalKey.length() + ')';
-            log.error(errMsg);
+            final String errMsg = String.format("CanonicalKey ``%s`` is too long (maxLen = %d, keyLen = %d, canonicalKeyLen = %d)", canonicalKey, this.maxKeyLength.get(), key.length(), canonicalKey.length());
+            log.warn(errMsg);
             throw new IllegalArgumentException(errMsg);
         }
 


### PR DESCRIPTION
The original error message lacked the information for end users to take action. Also added a log so that the information can still be accessed even when the exception is swallowed.