### PR TITLE
Provide pluggable hashing and lookup strategy for NodeLocator

### DIFF
--- a/evcache-core/build.gradle
+++ b/evcache-core/build.gradle
@@ -1,5 +1,10 @@
+plugins {
+    id "me.champeau.jmh" version "0.6.6"
+}
+
 apply plugin: 'java'
 apply plugin: 'eclipse'
+apply plugin: 'me.champeau.jmh'
 
 sourceSets.main.java.srcDir 'src/main/java'
 sourceSets.main.resources.srcDir 'src/main/resources'
@@ -39,6 +44,7 @@ dependencies {
         compile group:"joda-time",                    name:"joda-time",                        version:"latest.release"
         compile group:"javax.annotation",             name:"javax.annotation-api",             version:"latest.release"
         compile group:"com.github.fzakaria",          name:"ascii85",                          version:"latest.release"
+        compile group:"net.openhft",                  name:"zero-allocation-hashing",          version:"latest.release"
 
         testCompile group:"org.testng",               name:"testng",                           version:"7.5"
         testCompile group:"com.beust",                name:"jcommander",                       version:"1.72"
@@ -48,4 +54,13 @@ dependencies {
 
 javadoc {
     failOnError = false
+}
+
+jmh {
+    jmhVersion = '1.35'
+    warmupIterations = 2
+    iterations = 2
+    fork = 1
+    zip64 = true
+    profilers = ['gc', 'stack']
 }

--- a/evcache-core/src/jmh/java/com/netflix/evcache/pool/NodeLocatorBenchmark.java
+++ b/evcache-core/src/jmh/java/com/netflix/evcache/pool/NodeLocatorBenchmark.java
@@ -1,0 +1,112 @@
+package com.netflix.evcache.pool;
+
+import net.spy.memcached.DefaultHashAlgorithm;
+import net.spy.memcached.MemcachedNode;
+import net.spy.memcached.NodeLocator;
+import net.spy.memcached.util.DefaultKetamaNodeLocatorConfiguration;
+import net.spy.memcached.util.KetamaNodeLocatorConfiguration;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+import com.netflix.evcache.pool.NodeLocatorLookup.ArrayNodeLocatorLookup;
+import com.netflix.evcache.pool.NodeLocatorLookup.EytzingerNodeLocatorLookup;
+import com.netflix.evcache.pool.NodeLocatorLookup.TreeMapNodeLocatorLookup;
+import com.netflix.evcache.pool.NodeLocatorLookup.DirectApproximateNodeLocatorLookup;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeMap;
+import java.util.function.Function;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@State(Scope.Benchmark)
+public class NodeLocatorBenchmark {
+    @Param({"10", "120"})
+    int nodeCount;
+
+    @Param({"2000"})
+    int keyCount;
+
+    @Param({"0", "50"})
+    int keyTailLength;
+
+    @Param({"legacy", "array", "eytzinger", "direct"})
+    String locator;
+
+    @Param({"ketama-md5", "simple-fnv1a", "ketama-murmur3"})
+    String hashRing;
+
+    NodeLocator impl;
+
+    List<MemcachedNode> nodes;
+
+    String[] keys;
+
+    static Function<TreeMap<Long, MemcachedNode>, NodeLocatorLookup<MemcachedNode>> findLookupFactory(String locator) {
+        if (locator.equals("legacy")) {
+            return TreeMapNodeLocatorLookup::new;
+        } else if (locator.equals("array")) {
+            return ArrayNodeLocatorLookup::new;
+        } else if (locator.equals("eytzinger")) {
+            return EytzingerNodeLocatorLookup::new;
+        } else if (locator.equals("direct")) {
+            return DirectApproximateNodeLocatorLookup::new;
+        } else {
+            throw new RuntimeException("Unknown locator: " + locator);
+        }
+    }
+
+    static HashRingAlgorithm findHashRingAlgorithm(String hashRing) {
+        if (hashRing.equals("ketama-md5")) {
+            return new HashRingAlgorithm.KetamaMd5HashRingAlgorithm();
+        } else if (hashRing.equals("simple-fnv1a")) {
+            return new HashRingAlgorithm.SimpleHashRingAlgorithm(DefaultHashAlgorithm.FNV1A_64_HASH);
+        } else if (hashRing.equals("ketama-murmur3")) {
+            return new HashRingAlgorithm.KetamaMurmur3HashRingAlgorithm();
+        } else {
+            throw new RuntimeException("Unknown hash ring: " + hashRing);
+        }
+    }
+
+    @Setup
+    public void setup() {
+        nodes = new ArrayList<>();
+        for (int i = 1; i <= nodeCount; i++) {
+            MemcachedNode node = mock(MemcachedNode.class);
+            when(node.getSocketAddress()).thenReturn(new InetSocketAddress("100.94.221." + i, 11211));
+            nodes.add(node);
+        }
+
+        EVCacheClient client = mock(EVCacheClient.class);
+        when(client.getAppName()).thenReturn("mockApp");
+        when(client.getServerGroupName()).thenReturn("mockAppServerGroup");
+        KetamaNodeLocatorConfiguration conf = new DefaultKetamaNodeLocatorConfiguration();
+
+        HashRingAlgorithm hashRingAlgorithm = findHashRingAlgorithm(hashRing);
+        Function<TreeMap<Long, MemcachedNode>, NodeLocatorLookup<MemcachedNode>> lookupFactory = findLookupFactory(locator);
+
+        impl = new EVCacheNodeLocator(client, nodes, hashRingAlgorithm, conf, lookupFactory);
+
+        keys = new String[keyCount];
+        for (int i = 0; i < keyCount; i++) {
+            keys[i] = "key_" + i;
+            for (int j = 0; j < keyTailLength; j++) {
+                keys[i] += (char)('a' + (i % 26));
+            }
+        }
+    }
+
+    @Benchmark
+    public void testGetPrimary(Blackhole bh) {
+        for (int i = 0; i < keyCount; i++) {
+            bh.consume(impl.getPrimary(keys[i]));
+        }
+    }
+}

--- a/evcache-core/src/main/java/com/netflix/evcache/pool/HashRingAlgorithm.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/pool/HashRingAlgorithm.java
@@ -1,0 +1,65 @@
+package com.netflix.evcache.pool;
+
+import net.spy.memcached.DefaultHashAlgorithm;
+import net.spy.memcached.HashAlgorithm;
+
+/**
+ * Description of a hash ring algorithm. A hash ring algorithm has a hash
+ * function, and a way to split the hash into parts in the case of a
+ * ketama-like algorithm.
+ */
+public interface HashRingAlgorithm {
+
+    long hash(CharSequence key);
+
+    int getCountHashParts();
+
+    void getHashPartsInto(CharSequence key, long[] parts);
+
+    static class SimpleHashRingAlgorithm implements HashRingAlgorithm {
+        HashAlgorithm hashAlgorithm;
+
+        public SimpleHashRingAlgorithm(HashAlgorithm hashAlgorithm) {
+            this.hashAlgorithm = hashAlgorithm;
+        }
+
+        @Override
+        public long hash(CharSequence key) {
+            return hashAlgorithm.hash(key.toString());
+        }
+
+        @Override
+        public int getCountHashParts() {
+            return 1;
+        }
+
+        @Override
+        public void getHashPartsInto(CharSequence key, long[] parts) {
+            parts[0] = hash(key);
+        }
+    }
+
+    static class KetamaMd5HashRingAlgorithm implements HashRingAlgorithm {
+        @Override
+        public long hash(CharSequence key) {
+            return DefaultHashAlgorithm.KETAMA_HASH.hash(key.toString());
+        }
+
+        @Override
+        public int getCountHashParts() {
+            return 4;
+        }
+
+        @Override
+        public void getHashPartsInto(CharSequence key, long[] parts) {
+            byte[] digest = DefaultHashAlgorithm.computeMd5(key.toString());
+            for (int h = 0; h < 4; h++) {
+                parts[h] = ((long) (digest[3 + h * 4] & 0xFF) << 24)
+                        | ((long) (digest[2 + h * 4] & 0xFF) << 16)
+                        | ((long) (digest[1 + h * 4] & 0xFF) << 8)
+                        | (digest[h * 4] & 0xFF);
+            }
+        }
+    }
+
+}

--- a/evcache-core/src/main/java/com/netflix/evcache/pool/NodeLocatorLookup.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/pool/NodeLocatorLookup.java
@@ -1,0 +1,36 @@
+package com.netflix.evcache.pool;
+
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.HashMap;
+
+/**
+ * A lookup for the node locator.
+ *
+ * The hash is a 64-bit long, but the value is masked to a 32-bit int and the
+ * upper 32-bits are ignored.
+ */
+public interface NodeLocatorLookup<V> {
+    V wrappingCeilingValue(long hash);
+
+    static class TreeMapNodeLocatorLookup<V> implements NodeLocatorLookup<V> {
+
+        private final TreeMap<Long, V> map;
+
+        TreeMapNodeLocatorLookup(TreeMap<Long, V> map) {
+            this.map = map;
+        }
+
+        @Override
+        public V wrappingCeilingValue(long hash) {
+            Map.Entry<Long, V> entry = map.ceilingEntry(hash);
+            if (entry == null) {
+                entry = map.firstEntry();
+            }
+            return entry.getValue();
+        }
+    }
+
+}

--- a/evcache-core/src/main/java/com/netflix/evcache/pool/NodeLocatorLookup.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/pool/NodeLocatorLookup.java
@@ -33,4 +33,216 @@ public interface NodeLocatorLookup<V> {
         }
     }
 
+    /**
+     * A lookup for the node locator using sorted arrays and binary search.
+     */
+    static class ArrayNodeLocatorLookup<V> implements NodeLocatorLookup<V> {
+        private final long[] hashes;
+        private final V[] values;
+
+        @SuppressWarnings("unchecked")
+        ArrayNodeLocatorLookup(TreeMap<Long, V> map) {
+            int size = map.size();
+            this.hashes = new long[size];
+            this.values = (V[]) new Object[size];
+
+            int i = 0;
+            for (Map.Entry<Long, V> entry : map.entrySet()) {
+                hashes[i] = entry.getKey();
+                values[i] = entry.getValue();
+                i++;
+            }
+        }
+
+        @Override
+        public V wrappingCeilingValue(long hash) {
+            int index = binarySearchCeiling(hash);
+            return values[index];
+        }
+
+        private int binarySearchCeiling(long hash) {
+            // If the hash is greater than all values, wrap around to first element
+            if (hash > hashes[hashes.length - 1]) {
+                return 0;
+            }
+
+            int index = Arrays.binarySearch(hashes, hash);
+            if (index >= 0) {
+                return index; // exact match
+            }
+
+            // Arrays.binarySearch returns (-(insertion point) - 1) when key not found
+            // We want the insertion point, which is the ceiling
+            return -index - 1;
+        }
+    }
+
+    /**
+     * A lookup for the node locator using the Eytzinger layout.
+     */
+    static class EytzingerNodeLocatorLookup<V> implements NodeLocatorLookup<V> {
+
+        private final int[] hashes;
+        private final V[] values;
+        private final int leftmostNodePosition;
+
+        EytzingerNodeLocatorLookup(TreeMap<Long, V> newNodeMap) {
+            // Convert the sorted hashes to Eytzinger layout
+            long[] sortedHashes = newNodeMap.keySet().stream().mapToLong(Long::longValue).toArray();
+            this.hashes = new int[sortedHashes.length];
+            sortedToEytzinger(sortedHashes, this.hashes, 0, new int[]{0});
+
+            // Store nodes in corresponding Eytzinger order
+            this.values = constructValueArray(hashes.length);
+            for (int i = 0; i < hashes.length; i++) {
+                this.values[i] = newNodeMap.get(Long.valueOf((long)hashes[i] & 0xffffffffL));
+            }
+
+            // we can set the leftmost node position directly because the
+            // Eytzinger layout is a complete binary tree, this avoids some
+            // unnecessary iterations when the search wraps around the ring
+            int _leftmostNodePosition = 0;
+            while (2 * _leftmostNodePosition + 1 < hashes.length) {
+                _leftmostNodePosition = 2 * _leftmostNodePosition + 1;
+            }
+            this.leftmostNodePosition = _leftmostNodePosition;
+
+        }
+
+        @SuppressWarnings("unchecked")
+        private V[] constructValueArray(int length) {
+            return (V[]) new Object[length];
+        }
+
+        @Override
+        public V wrappingCeilingValue(long hash) {
+            int pos = eytzingerCeilingPosition(hash);
+            return values[pos];
+        }
+
+        private int eytzingerCeilingPosition(long hash) {
+            int pos = 0;
+            int candidate = -1;
+
+            while (pos < hashes.length) {
+                long nodeHash = ((long) hashes[pos]) & 0xffffffffL;
+                if (hash <= nodeHash) {
+                    candidate = pos;
+                    pos = 2 * pos + 1;
+                } else {
+                    pos = 2 * pos + 2;
+                }
+            }
+
+            if (candidate == -1) {
+                return leftmostNodePosition;
+            }
+
+            return candidate;
+        }
+
+        private static void sortedToEytzinger(long[] sorted, int[] eytzinger, int i, int[] pos) {
+            if (i >= eytzinger.length || pos[0] >= sorted.length) return;
+
+            sortedToEytzinger(sorted, eytzinger, 2 * i + 1, pos);
+            eytzinger[i] = (int)sorted[pos[0]];
+            pos[0]++;
+            sortedToEytzinger(sorted, eytzinger, 2 * i + 2, pos);
+        }
+    }
+
+    /**
+     * A lookup using a two-level direct mapping approach.
+     * Level 1: Fixed-size array of bytes/chars mapping hash ranges to node indices
+     * Level 2: Compact array of actual nodes
+     */
+    static class DirectApproximateNodeLocatorLookup<V> implements NodeLocatorLookup<V> {
+        private static final int BUCKET_BITS = 19;
+        private static final int BUCKET_COUNT = 1 << BUCKET_BITS;
+        private static final int BUCKET_MASK = BUCKET_COUNT - 1;
+        private static final int BYTE_MAX_VALUE = 255;
+
+        private final Object bucketToNodeIndex; // First level: either byte[] or char[]
+        private final V[] nodes; // Second level: actual nodes
+        private final int nodeCount; // Number of unique nodes
+        private final boolean usingBytes;
+
+        @SuppressWarnings("unchecked")
+        DirectApproximateNodeLocatorLookup(TreeMap<Long, V> map) {
+            // Determine if we can use bytes based on unique node count
+            Object[] uniqueValues = new LinkedHashSet<>(map.values()).toArray();
+            this.nodeCount = uniqueValues.length;
+            this.usingBytes = nodeCount <= BYTE_MAX_VALUE;
+
+            // Initialize appropriate array type
+            this.bucketToNodeIndex = usingBytes ? new byte[BUCKET_COUNT] : new char[BUCKET_COUNT];
+
+            this.nodes = (V[]) new Object[nodeCount];
+            System.arraycopy(uniqueValues, 0, nodes, 0, nodeCount);
+
+            Map<V, Integer> valueToIndex = new HashMap<>();
+            for (int i = 0; i < nodeCount; i++) {
+                valueToIndex.put((V) uniqueValues[i], i);
+            }
+
+            // Fill bucket table
+            long prevHash = -1;
+            int prevIndex = 0;
+
+            for (Map.Entry<Long, V> entry : map.entrySet()) {
+                long hash = entry.getKey();
+                int nodeIndex = valueToIndex.get(entry.getValue());
+
+                int startBucket = (prevHash == -1) ? 0 : getBucketIndex(prevHash + 1);
+                int endBucket = getBucketIndex(hash);
+
+                int indexToUse = nodeIndex;
+                if (prevHash != -1) {
+                    indexToUse = prevIndex;
+                }
+
+                while (startBucket != endBucket) {
+                    setBucketIndex(startBucket, indexToUse);
+                    startBucket = (startBucket + 1) & BUCKET_MASK;
+                }
+                setBucketIndex(endBucket, nodeIndex);
+
+                prevHash = hash;
+                prevIndex = nodeIndex;
+            }
+
+            // Fill remaining buckets to handle wrap-around
+            if (prevHash != -1) {
+                int startBucket = getBucketIndex(prevHash + 1);
+                int endBucket = getBucketIndex(-1L);
+                while (startBucket != endBucket) {
+                    setBucketIndex(startBucket, prevIndex);
+                    startBucket = (startBucket + 1) & BUCKET_MASK;
+                }
+                setBucketIndex(endBucket, prevIndex);
+            }
+        }
+
+        private void setBucketIndex(int bucket, int value) {
+            if (usingBytes) {
+                ((byte[]) bucketToNodeIndex)[bucket] = (byte) value;
+            } else {
+                ((char[]) bucketToNodeIndex)[bucket] = (char) value;
+            }
+        }
+
+        private int getBucketValue(int bucket) {
+            return usingBytes ? ((byte[]) bucketToNodeIndex)[bucket] & 0xFF : ((char[]) bucketToNodeIndex)[bucket];
+        }
+
+        private static int getBucketIndex(long hash) {
+            return (int) ((hash >>> (32 - BUCKET_BITS)) & BUCKET_MASK);
+        }
+
+        @Override
+        public V wrappingCeilingValue(long hash) {
+            return nodes[getBucketValue(getBucketIndex(hash))];
+        }
+    }
+
 }

--- a/evcache-core/src/test/java/com/netflix/evcache/pool/NodeLocatorLookupTest.java
+++ b/evcache-core/src/test/java/com/netflix/evcache/pool/NodeLocatorLookupTest.java
@@ -1,0 +1,36 @@
+package com.netflix.evcache.pool;
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+import java.util.TreeMap;
+
+public class NodeLocatorLookupTest {
+
+    @Test
+    public void testTreeMapNodeLocatorLookup() {
+        TreeMap<Long, String> map = new TreeMap<>();
+        map.put(10L, "node1");
+        map.put(20L, "node2");
+        map.put(30L, "node3");
+
+        NodeLocatorLookup<String> lookup = new NodeLocatorLookup.TreeMapNodeLocatorLookup<>(map);
+
+        // Test exact matches
+        assertEquals(lookup.wrappingCeilingValue(10L), "node1");
+        assertEquals(lookup.wrappingCeilingValue(20L), "node2");
+        assertEquals(lookup.wrappingCeilingValue(30L), "node3");
+
+        // Test ceiling behavior
+        assertEquals(lookup.wrappingCeilingValue(15L), "node2");
+        assertEquals(lookup.wrappingCeilingValue(25L), "node3");
+
+        // Test wrapping behavior (values greater than max should wrap to first node)
+        assertEquals(lookup.wrappingCeilingValue(35L), "node1");
+        assertEquals(lookup.wrappingCeilingValue(Long.MAX_VALUE), "node1");
+
+        // Test values less than min
+        assertEquals(lookup.wrappingCeilingValue(5L), "node1");
+        assertEquals(lookup.wrappingCeilingValue(0L), "node1");
+    }
+}

--- a/evcache-core/src/test/java/com/netflix/evcache/pool/NodeLocatorLookupTest.java
+++ b/evcache-core/src/test/java/com/netflix/evcache/pool/NodeLocatorLookupTest.java
@@ -33,4 +33,86 @@ public class NodeLocatorLookupTest {
         assertEquals(lookup.wrappingCeilingValue(5L), "node1");
         assertEquals(lookup.wrappingCeilingValue(0L), "node1");
     }
+
+    @Test
+    public void testArrayNodeLocatorLookup() {
+        TreeMap<Long, String> map = new TreeMap<>();
+        map.put(10L, "node1");
+        map.put(20L, "node2");
+        map.put(30L, "node3");
+
+        NodeLocatorLookup<String> lookup = new NodeLocatorLookup.ArrayNodeLocatorLookup<>(map);
+
+        // Test exact matches
+        assertEquals(lookup.wrappingCeilingValue(10L), "node1");
+        assertEquals(lookup.wrappingCeilingValue(20L), "node2");
+        assertEquals(lookup.wrappingCeilingValue(30L), "node3");
+
+        // Test ceiling behavior
+        assertEquals(lookup.wrappingCeilingValue(15L), "node2");
+        assertEquals(lookup.wrappingCeilingValue(25L), "node3");
+
+        // Test wrapping behavior (values greater than max should wrap to first node)
+        assertEquals(lookup.wrappingCeilingValue(35L), "node1");
+        assertEquals(lookup.wrappingCeilingValue(Long.MAX_VALUE), "node1");
+
+        // Test values less than min
+        assertEquals(lookup.wrappingCeilingValue(5L), "node1");
+        assertEquals(lookup.wrappingCeilingValue(0L), "node1");
+    }
+
+    @Test
+    public void testEytzingerNodeLocatorLookup() {
+        TreeMap<Long, String> map = new TreeMap<>();
+        map.put(10L, "node1");
+        map.put(20L, "node2");
+        map.put(30L, "node3");
+
+        NodeLocatorLookup<String> lookup = new NodeLocatorLookup.EytzingerNodeLocatorLookup<>(map);
+
+        // Test exact matches
+        assertEquals(lookup.wrappingCeilingValue(10L), "node1");
+        assertEquals(lookup.wrappingCeilingValue(20L), "node2");
+        assertEquals(lookup.wrappingCeilingValue(30L), "node3");
+
+        // Test ceiling behavior
+        assertEquals(lookup.wrappingCeilingValue(15L), "node2");
+        assertEquals(lookup.wrappingCeilingValue(25L), "node3");
+
+        // Test wrapping behavior (values greater than max should wrap to first node)
+        assertEquals(lookup.wrappingCeilingValue(35L), "node1");
+        assertEquals(lookup.wrappingCeilingValue(Long.MAX_VALUE), "node1");
+
+        // Test values less than min
+        assertEquals(lookup.wrappingCeilingValue(5L), "node1");
+        assertEquals(lookup.wrappingCeilingValue(0L), "node1");
+    }
+
+    @Test
+    public void testLargeScaleConsistency() {
+        // Generate a large TreeMap with 1 million entries
+        TreeMap<Long, String> map = new TreeMap<>();
+        int numEntries = 1_000_000;
+        for (int i = 0; i < numEntries; i++) {
+            map.put((long) i * 100, "node" + i);
+        }
+
+        // Create all three implementations
+        NodeLocatorLookup<String> arrayLookup = new NodeLocatorLookup.ArrayNodeLocatorLookup<>(map);
+        NodeLocatorLookup<String> eytzingerLookup = new NodeLocatorLookup.EytzingerNodeLocatorLookup<>(map);
+        NodeLocatorLookup<String> treeMapLookup = new NodeLocatorLookup.TreeMapNodeLocatorLookup<>(map);
+
+        // Test a range of values including edge cases
+        for (long i = -1000; i <= (numEntries * 100L + 1000); i++) {
+            String arrayResult = arrayLookup.wrappingCeilingValue(i);
+            String eytzingerResult = eytzingerLookup.wrappingCeilingValue(i);
+            String treeMapResult = treeMapLookup.wrappingCeilingValue(i);
+
+            // Assert all implementations return the same result
+            assertEquals(arrayResult, eytzingerResult,
+                    "Array and Eytzinger implementations differ for key " + i);
+            assertEquals(arrayResult, treeMapResult,
+                    "Array and TreeMap implementations differ for key " + i);
+        }
+    }
 }

--- a/evcache-core/src/test/java/test-suite.xml
+++ b/evcache-core/src/test/java/test-suite.xml
@@ -1,5 +1,10 @@
 <!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
 <suite name="evcache-client-tests">
+  <test name="UnitTests">
+    <classes>
+      <class name="com.netflix.evcache.pool.NodeLocatorLookupTest" />
+    </classes>
+  </test>
   <test name="MockTests">
     <classes>
       <class name="com.netflix.evcache.test.MockEVCacheTest" />


### PR DESCRIPTION
A significant part of the `getBulk` with large keylists is spent performing NodeLocator lookups (`getPrimary`) to identify which node to send traffic to. The current Ketama configuration is based on MD5 which is no longer best-in-class, and uses a Java TreeMap which is not the most efficient approach for large arrays.

This PR makes the components of the NodeLocator pluggable with different hash/ring functions and different strategies for storage of the hash-ring-to-node lookup function. It then provides a number of alternative implementations. It does NOT change any of the existing implementation / configuration, which would need to come in a follow-up.

Implementation configuration choices range from 30% faster to ~10x faster.

<img width="1426" alt="image" src="https://github.com/user-attachments/assets/11b28e93-75df-4a2a-b520-879bc1d29fb6">
