### PR TITLE
perf: perform the getPrimary lookup only once during getBulk

### DIFF
--- a/evcache-core/src/main/java/com/netflix/evcache/pool/EVCacheClient.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/pool/EVCacheClient.java
@@ -188,7 +188,7 @@ public class EVCacheClient {
         return this.maxHashLength.get();
     }
 
-    private boolean validateReadQueueSize(MemcachedNode node, String key, EVCache.Call call) {
+    private boolean validateReadQueueSize(MemcachedNode node, EVCache.Call call) {
         if (!(node instanceof EVCacheNode)) {
             return true;
         }
@@ -972,7 +972,7 @@ public class EVCacheClient {
             if (enableChunking.get()) {
                 returnVal = assembleChunks(canonicalKeys, tc, hasZF);
             } else {
-                final BiPredicate<MemcachedNode, String> validator = (node, key) -> validateReadQueueSize(node, key, Call.BULK);
+                final BiPredicate<MemcachedNode, String> validator = (node, key) -> validateReadQueueSize(node, Call.BULK);
                 returnVal = evcacheMemcachedClient.asyncGetBulk(canonicalKeys, tc, null, validator)
                         .getSome(bulkReadTimeout.get(), TimeUnit.MILLISECONDS, _throwException, hasZF);
             }
@@ -984,7 +984,7 @@ public class EVCacheClient {
     }
 
     public <T> CompletableFuture<Map<String, T>> getAsyncBulk(Collection<String> canonicalKeys, Transcoder<T> tc) {
-        final BiPredicate<MemcachedNode, String> validator = (node, key) -> validateReadQueueSize(node, key, Call.COMPLETABLE_FUTURE_GET_BULK);
+        final BiPredicate<MemcachedNode, String> validator = (node, key) -> validateReadQueueSize(node, Call.COMPLETABLE_FUTURE_GET_BULK);
         if (tc == null) tc = (Transcoder<T>) getTranscoder();
         return evcacheMemcachedClient
                 .asyncGetBulk(canonicalKeys, tc, null, validator)
@@ -999,7 +999,7 @@ public class EVCacheClient {
             if (enableChunking.get()) {
                 return assembleChunks(canonicalKeys, tc, hasZF, scheduler);
             } else {
-                final BiPredicate<MemcachedNode, String> validator = (node, key) -> validateReadQueueSize(node, key, Call.BULK);
+                final BiPredicate<MemcachedNode, String> validator = (node, key) -> validateReadQueueSize(node, Call.BULK);
                 return evcacheMemcachedClient.asyncGetBulk(canonicalKeys, tc, null, validator)
                     .getSome(bulkReadTimeout.get(), TimeUnit.MILLISECONDS, _throwException, hasZF, scheduler);
             }


### PR DESCRIPTION
We can avoid doing the (potentially) expensive getPrimary call twice on the bulk get path with a little refactor. This retains the same functionality but pushes the validation logic and error emit into a callback, which allows metrics to work as-is.

before

![image](https://github.com/user-attachments/assets/a4443443-2095-4031-aea0-ba8acbd4dbcc)

after

![image](https://github.com/user-attachments/assets/68b5c143-4f1a-4f53-b7a8-4dfbdff57be7)
