### PR TITLE
Refactor NodeLocator hash and lookup and provide faster implementations

### DIFF
--- a/evcache-core/src/main/java/com/netflix/evcache/pool/EVCacheNodeLocator.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/pool/EVCacheNodeLocator.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
 
 import com.netflix.evcache.pool.HashRingAlgorithm.SimpleHashRingAlgorithm;
 import com.netflix.evcache.pool.HashRingAlgorithm.KetamaMd5HashRingAlgorithm;
-import com.netflix.evcache.pool.NodeLocatorLookup.TreeMapNodeLocatorLookup;
+import com.netflix.evcache.pool.NodeLocatorLookup.EytzingerNodeLocatorLookup;
 import com.netflix.evcache.util.EVCacheConfig;
 
 import net.spy.memcached.DefaultHashAlgorithm;
@@ -76,7 +76,7 @@ public class EVCacheNodeLocator implements NodeLocator {
                 alg == DefaultHashAlgorithm.KETAMA_HASH ? new KetamaMd5HashRingAlgorithm()
                         : new SimpleHashRingAlgorithm(alg),
                 conf,
-                TreeMapNodeLocatorLookup::new);
+                EytzingerNodeLocatorLookup::new);
     }
 
     private EVCacheNodeLocator(EVCacheClient client, TreeMap<Long, MemcachedNode> smn, Collection<MemcachedNode> an, HashRingAlgorithm hashRingAlgorithm, KetamaNodeLocatorConfiguration conf, Function<TreeMap<Long, MemcachedNode>, NodeLocatorLookup<MemcachedNode>> lookupFactory) {

--- a/evcache-core/src/main/java/com/netflix/evcache/pool/HashRingAlgorithm.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/pool/HashRingAlgorithm.java
@@ -1,0 +1,65 @@
+package com.netflix.evcache.pool;
+
+import net.spy.memcached.DefaultHashAlgorithm;
+import net.spy.memcached.HashAlgorithm;
+
+/**
+ * Description of a hash ring algorithm. A hash ring algorithm has a hash
+ * function, and a way to split the hash into parts in the case of a
+ * ketama-like algorithm.
+ */
+public interface HashRingAlgorithm {
+
+    long hash(CharSequence key);
+
+    int getCountHashParts();
+
+    void getHashPartsInto(CharSequence key, long[] parts);
+
+    static class SimpleHashRingAlgorithm implements HashRingAlgorithm {
+        HashAlgorithm hashAlgorithm;
+
+        public SimpleHashRingAlgorithm(HashAlgorithm hashAlgorithm) {
+            this.hashAlgorithm = hashAlgorithm;
+        }
+
+        @Override
+        public long hash(CharSequence key) {
+            return hashAlgorithm.hash(key.toString());
+        }
+
+        @Override
+        public int getCountHashParts() {
+            return 1;
+        }
+
+        @Override
+        public void getHashPartsInto(CharSequence key, long[] parts) {
+            parts[0] = hash(key);
+        }
+    }
+
+    static class KetamaMd5HashRingAlgorithm implements HashRingAlgorithm {
+        @Override
+        public long hash(CharSequence key) {
+            return DefaultHashAlgorithm.KETAMA_HASH.hash(key.toString());
+        }
+
+        @Override
+        public int getCountHashParts() {
+            return 4;
+        }
+
+        @Override
+        public void getHashPartsInto(CharSequence key, long[] parts) {
+            byte[] digest = DefaultHashAlgorithm.computeMd5(key.toString());
+            for (int h = 0; h < 4; h++) {
+                parts[h] = ((long) (digest[3 + h * 4] & 0xFF) << 24)
+                        | ((long) (digest[2 + h * 4] & 0xFF) << 16)
+                        | ((long) (digest[1 + h * 4] & 0xFF) << 8)
+                        | (digest[h * 4] & 0xFF);
+            }
+        }
+    }
+
+}

--- a/evcache-core/src/main/java/com/netflix/evcache/pool/HashRingAlgorithm.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/pool/HashRingAlgorithm.java
@@ -3,6 +3,10 @@ package com.netflix.evcache.pool;
 import net.spy.memcached.DefaultHashAlgorithm;
 import net.spy.memcached.HashAlgorithm;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
 /**
  * Description of a hash ring algorithm. A hash ring algorithm has a hash
  * function, and a way to split the hash into parts in the case of a
@@ -40,9 +44,33 @@ public interface HashRingAlgorithm {
     }
 
     static class KetamaMd5HashRingAlgorithm implements HashRingAlgorithm {
+        private static MessageDigest md5Digest = null;
+
+        static {
+            try {
+                md5Digest = MessageDigest.getInstance("MD5");
+            } catch (NoSuchAlgorithmException e) {
+                throw new RuntimeException("MD5 not supported", e);
+            }
+        }
+
         @Override
         public long hash(CharSequence key) {
-            return DefaultHashAlgorithm.KETAMA_HASH.hash(key.toString());
+            // manually inlined from DefaultHashAlgorithm, avoids the Charset lookup
+            long rv = 0;
+            MessageDigest md5;
+            try {
+              md5 = (MessageDigest) md5Digest.clone();
+            } catch (CloneNotSupportedException e) {
+              throw new RuntimeException("clone of MD5 not supported", e);
+            }
+            md5.update(key.toString().getBytes(StandardCharsets.UTF_8));
+            byte[] bKey = md5.digest();
+            rv = ((long) (bKey[3] & 0xFF) << 24)
+                    | ((long) (bKey[2] & 0xFF) << 16)
+                    | ((long) (bKey[1] & 0xFF) << 8)
+                    | (bKey[0] & 0xFF);
+            return rv & 0xffffffffL; /* Truncate to 32-bits */
         }
 
         @Override
@@ -61,5 +89,4 @@ public interface HashRingAlgorithm {
             }
         }
     }
-
 }

--- a/evcache-core/src/main/java/com/netflix/evcache/pool/NodeLocatorLookup.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/pool/NodeLocatorLookup.java
@@ -1,0 +1,36 @@
+package com.netflix.evcache.pool;
+
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.HashMap;
+
+/**
+ * A lookup for the node locator.
+ *
+ * The hash is a 64-bit long, but the value is masked to a 32-bit int and the
+ * upper 32-bits are ignored.
+ */
+public interface NodeLocatorLookup<V> {
+    V wrappingCeilingValue(long hash);
+
+    static class TreeMapNodeLocatorLookup<V> implements NodeLocatorLookup<V> {
+
+        private final TreeMap<Long, V> map;
+
+        TreeMapNodeLocatorLookup(TreeMap<Long, V> map) {
+            this.map = map;
+        }
+
+        @Override
+        public V wrappingCeilingValue(long hash) {
+            Map.Entry<Long, V> entry = map.ceilingEntry(hash);
+            if (entry == null) {
+                entry = map.firstEntry();
+            }
+            return entry.getValue();
+        }
+    }
+
+}

--- a/evcache-core/src/main/java/com/netflix/evcache/pool/NodeLocatorLookup.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/pool/NodeLocatorLookup.java
@@ -1,10 +1,8 @@
 package com.netflix.evcache.pool;
 
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.Arrays;
-import java.util.LinkedHashSet;
-import java.util.HashMap;
 
 /**
  * A lookup for the node locator.
@@ -30,6 +28,111 @@ public interface NodeLocatorLookup<V> {
                 entry = map.firstEntry();
             }
             return entry.getValue();
+        }
+    }
+
+    static <V> void coalesceMap(TreeMap<Long, V> map) {
+        if (map == null || map.isEmpty()) {
+            return;
+        }
+
+        // we only ever use the 'ceiling' value, [ie: the next one above]
+        // so if we find three nodes 1->A 2->A 3->B, we can collapse to 2->A 3->B
+        // and results will be identical
+
+        Long prevKey = null;
+        V prevValue = null;
+        ArrayList<Long> keysToRemove = new ArrayList<>();
+        for (Long key : map.keySet().toArray(new Long[0])) {
+            V currentValue = map.get(key);
+
+            if (prevValue != null && prevValue.equals(currentValue)) {
+                keysToRemove.add(prevKey);
+            }
+
+            prevKey = key;
+            prevValue = currentValue;
+        }
+
+        for (Long key : keysToRemove) {
+            map.remove(key);
+        }
+    }
+
+    /**
+     * A lookup for the node locator using the Eytzinger layout.
+     */
+    static class EytzingerNodeLocatorLookup<V> implements NodeLocatorLookup<V> {
+
+        private final int[] hashes;
+        private final V[] values;
+        private final int leftmostNodePosition;
+
+        EytzingerNodeLocatorLookup(TreeMap<Long, V> newNodeMap) {
+            // Convert the sorted hashes to Eytzinger layout
+            TreeMap<Long, V> clone = new TreeMap<>(newNodeMap);
+            coalesceMap(clone);
+
+            long[] sortedHashes = clone.keySet().stream().mapToLong(Long::longValue).toArray();
+            this.hashes = new int[sortedHashes.length];
+            sortedToEytzinger(sortedHashes, this.hashes, 0, new int[]{0});
+
+            // Store nodes in corresponding Eytzinger order
+            this.values = constructValueArray(hashes.length);
+            for (int i = 0; i < hashes.length; i++) {
+                this.values[i] = clone.get(Long.valueOf((long)hashes[i] & 0xffffffffL));
+            }
+
+            // we can set the leftmost node position directly because the
+            // Eytzinger layout is a complete binary tree, this avoids some
+            // unnecessary iterations when the search wraps around the ring
+            int _leftmostNodePosition = 0;
+            while (2 * _leftmostNodePosition + 1 < hashes.length) {
+                _leftmostNodePosition = 2 * _leftmostNodePosition + 1;
+            }
+            this.leftmostNodePosition = _leftmostNodePosition;
+
+        }
+
+        @SuppressWarnings("unchecked")
+        private V[] constructValueArray(int length) {
+            return (V[]) new Object[length];
+        }
+
+        @Override
+        public V wrappingCeilingValue(long hash) {
+            int pos = eytzingerCeilingPosition(hash);
+            return values[pos];
+        }
+
+        private int eytzingerCeilingPosition(long hash) {
+            int pos = 0;
+            int candidate = -1;
+
+            while (pos < hashes.length) {
+                long nodeHash = ((long) hashes[pos]) & 0xffffffffL;
+                if (hash <= nodeHash) {
+                    candidate = pos;
+                    pos = 2 * pos + 1;
+                } else {
+                    pos = 2 * pos + 2;
+                }
+            }
+
+            if (candidate == -1) {
+                return leftmostNodePosition;
+            }
+
+            return candidate;
+        }
+
+        private static void sortedToEytzinger(long[] sorted, int[] eytzinger, int i, int[] pos) {
+            if (i >= eytzinger.length || pos[0] >= sorted.length) return;
+
+            sortedToEytzinger(sorted, eytzinger, 2 * i + 1, pos);
+            eytzinger[i] = (int)sorted[pos[0]];
+            pos[0]++;
+            sortedToEytzinger(sorted, eytzinger, 2 * i + 2, pos);
         }
     }
 

--- a/evcache-core/src/test/java/com/netflix/evcache/pool/NodeLocatorLookupTest.java
+++ b/evcache-core/src/test/java/com/netflix/evcache/pool/NodeLocatorLookupTest.java
@@ -1,0 +1,36 @@
+package com.netflix.evcache.pool;
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+import java.util.TreeMap;
+
+public class NodeLocatorLookupTest {
+
+    @Test
+    public void testTreeMapNodeLocatorLookup() {
+        TreeMap<Long, String> map = new TreeMap<>();
+        map.put(10L, "node1");
+        map.put(20L, "node2");
+        map.put(30L, "node3");
+
+        NodeLocatorLookup<String> lookup = new NodeLocatorLookup.TreeMapNodeLocatorLookup<>(map);
+
+        // Test exact matches
+        assertEquals(lookup.wrappingCeilingValue(10L), "node1");
+        assertEquals(lookup.wrappingCeilingValue(20L), "node2");
+        assertEquals(lookup.wrappingCeilingValue(30L), "node3");
+
+        // Test ceiling behavior
+        assertEquals(lookup.wrappingCeilingValue(15L), "node2");
+        assertEquals(lookup.wrappingCeilingValue(25L), "node3");
+
+        // Test wrapping behavior (values greater than max should wrap to first node)
+        assertEquals(lookup.wrappingCeilingValue(35L), "node1");
+        assertEquals(lookup.wrappingCeilingValue(Long.MAX_VALUE), "node1");
+
+        // Test values less than min
+        assertEquals(lookup.wrappingCeilingValue(5L), "node1");
+        assertEquals(lookup.wrappingCeilingValue(0L), "node1");
+    }
+}

--- a/evcache-core/src/test/java/com/netflix/evcache/pool/NodeLocatorLookupTest.java
+++ b/evcache-core/src/test/java/com/netflix/evcache/pool/NodeLocatorLookupTest.java
@@ -33,4 +33,55 @@ public class NodeLocatorLookupTest {
         assertEquals(lookup.wrappingCeilingValue(5L), "node1");
         assertEquals(lookup.wrappingCeilingValue(0L), "node1");
     }
+
+    @Test
+    public void testEytzingerNodeLocatorLookup() {
+        TreeMap<Long, String> map = new TreeMap<>();
+        map.put(10L, "node1");
+        map.put(20L, "node2");
+        map.put(30L, "node3");
+
+        NodeLocatorLookup<String> lookup = new NodeLocatorLookup.EytzingerNodeLocatorLookup<>(map);
+
+        // Test exact matches
+        assertEquals(lookup.wrappingCeilingValue(10L), "node1");
+        assertEquals(lookup.wrappingCeilingValue(20L), "node2");
+        assertEquals(lookup.wrappingCeilingValue(30L), "node3");
+
+        // Test ceiling behavior
+        assertEquals(lookup.wrappingCeilingValue(15L), "node2");
+        assertEquals(lookup.wrappingCeilingValue(25L), "node3");
+
+        // Test wrapping behavior (values greater than max should wrap to first node)
+        assertEquals(lookup.wrappingCeilingValue(35L), "node1");
+        assertEquals(lookup.wrappingCeilingValue(Long.MAX_VALUE), "node1");
+
+        // Test values less than min
+        assertEquals(lookup.wrappingCeilingValue(5L), "node1");
+        assertEquals(lookup.wrappingCeilingValue(0L), "node1");
+    }
+
+    @Test
+    public void testLargeScaleConsistency() {
+        // Generate a large TreeMap with 1 million entries
+        TreeMap<Long, String> map = new TreeMap<>();
+        int numEntries = 1_000_000;
+        for (int i = 0; i < numEntries; i++) {
+            map.put((long) i * 100, "node" + i);
+        }
+
+        // Create all three implementations
+        NodeLocatorLookup<String> eytzingerLookup = new NodeLocatorLookup.EytzingerNodeLocatorLookup<>(map);
+        NodeLocatorLookup<String> treeMapLookup = new NodeLocatorLookup.TreeMapNodeLocatorLookup<>(map);
+
+        // Test a range of values including edge cases
+        for (long i = -1000; i <= (numEntries * 100L + 1000); i++) {
+            String eytzingerResult = eytzingerLookup.wrappingCeilingValue(i);
+            String treeMapResult = treeMapLookup.wrappingCeilingValue(i);
+
+            // Assert all implementations return the same result
+            assertEquals(treeMapResult, eytzingerResult,
+                    "TreeMap and Eytzinger implementations differ for key " + i);
+        }
+    }
 }

--- a/evcache-core/src/test/java/test-suite.xml
+++ b/evcache-core/src/test/java/test-suite.xml
@@ -1,5 +1,10 @@
 <!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
 <suite name="evcache-client-tests">
+  <test name="UnitTests">
+    <classes>
+      <class name="com.netflix.evcache.pool.NodeLocatorLookupTest" />
+    </classes>
+  </test>
   <test name="MockTests">
     <classes>
       <class name="com.netflix.evcache.test.MockEVCacheTest" />


### PR DESCRIPTION
Three commits
1) extract the existing hashing function and the sort/lookup function to distinct components
2) add a BFS-organized layout for lookups
3) optimize the hashing function to avoid Charset lookup