### PR TITLE
client shutdown without wait time when bean is destroyed

### DIFF
--- a/evcache-core/src/main/java/com/netflix/evcache/pool/EVCacheClientPool.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/pool/EVCacheClientPool.java
@@ -1253,6 +1253,10 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
     }
 
     public void serverGroupDisabled(final ServerGroup serverGroup) {
+        serverGroupDisabled(serverGroup, 30);
+    }
+
+    public void serverGroupDisabled(final ServerGroup serverGroup, final long timeoutSeconds) {
         if (memcachedInstancesByServerGroup.containsKey(serverGroup)) {
             if (log.isDebugEnabled()) log.debug("\n\tApp : " + _appName + "\n\tServerGroup : " + serverGroup
                     + " has no active servers. Cleaning up this ServerGroup.");
@@ -1262,13 +1266,13 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
             setupAllEVCacheWriteClientsArray();
             for (EVCacheClient client : clients) {
                 if (log.isDebugEnabled()) log.debug("\n\tApp : " + _appName + "\n\tServerGroup : " + serverGroup
-                        + "\n\tClient : " + client + " will be shutdown in 30 seconds.");
-                client.shutdown(30, TimeUnit.SECONDS);
+                        + "\n\tClient : " + client + " will be shutdown in " + timeoutSeconds + " seconds.");
+                client.shutdown(timeoutSeconds, TimeUnit.SECONDS);
                 client.getConnectionObserver().shutdown();
             }
         }
         if (duetClientPool != null)
-            duetClientPool.serverGroupDisabled(serverGroup);
+            duetClientPool.serverGroupDisabled(serverGroup, timeoutSeconds);
     }
 
     public void refreshAsync(MemcachedNode node) {
@@ -1300,7 +1304,7 @@ public class EVCacheClientPool implements Runnable, EVCacheClientPoolMBean {
         
         for(ServerGroup serverGroup : memcachedInstancesByServerGroup.keySet()) {
             if (log.isDebugEnabled()) log.debug("\nSHUTDOWN\n\tApp : " + _appName + "\n\tServerGroup : " + serverGroup);
-            serverGroupDisabled(serverGroup);
+            serverGroupDisabled(serverGroup, 0);
         }
         setupMonitoring();
     }


### PR DESCRIPTION
A couple of clients hung up can cause this to exceed the shutdown limit.