### PR TITLE
Separate inactive node and write queue full metric

### DIFF
--- a/evcache-core/src/main/java/com/netflix/evcache/metrics/EVCacheMetricsFactory.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/metrics/EVCacheMetricsFactory.java
@@ -389,6 +389,7 @@ public final class EVCacheMetricsFactory {
     public static final String CALLBACK                         = "callback";
     public static final String VERIFY                           = "verify";
     public static final String READ_QUEUE_FULL                  = "readQueueFull";
+    public static final String WRITE_QUEUE_FULL                 = "writeQueueFull";
     public static final String INACTIVE_NODE                    = "inactiveNode";
     public static final String IGNORE_INACTIVE_NODES            = "ignoreInactiveNode";
     public static final String INCORRECT_CHUNKS                 = "incorrectNumOfChunks";

--- a/evcache-core/src/main/java/com/netflix/evcache/pool/EVCacheClient.java
+++ b/evcache-core/src/main/java/com/netflix/evcache/pool/EVCacheClient.java
@@ -289,9 +289,9 @@ public class EVCacheClient {
                 }
 
                 if(i++ > 3) {
-                    incrementFailure(EVCacheMetricsFactory.INACTIVE_NODE, call);
+                    incrementFailure(EVCacheMetricsFactory.WRITE_QUEUE_FULL, call);
                     if (log.isDebugEnabled()) log.debug("Node : " + evcNode + " for app : " + appName + "; zone : "
-                            + zone + " is not active. Will Fail Fast and the write will be dropped for key : " + key);
+                            + zone + " write queue is full. Will Fail Fast and the write will be dropped for key : " + key);
                     evcNode.shutdown();
                     return false;
                 }


### PR DESCRIPTION
Just to follow up on this [PR comment](https://github.com/Netflix/EVCache/pull/186/changes#r2914011851). Not sure how useful it is, but I think it's good to have this separation.